### PR TITLE
Fixes workdir lowercasing.

### DIFF
--- a/pmb/config/init.py
+++ b/pmb/config/init.py
@@ -39,7 +39,7 @@ def init(args):
     logging.info("Location of the 'work' path. Multiple chroots (native,"
                  " device arch, device rootfs) will be created in there.")
     cfg["pmbootstrap"]["work"] = pmb.helpers.cli.ask(args, "Work path",
-                                                     None, args.work)
+                                                     None, args.work, False)
     os.makedirs(cfg["pmbootstrap"]["work"], 0o700, True)
 
     # Parallel job count


### PR DESCRIPTION
The `cli.ask` command would forcibly lowercase the whole string. This
made the script unusable on a non-FHS-compliant system, like mine, where
the users's directories are under `/Users/`.

* * *

See [`cli.ask`](https://github.com/postmarketOS/pmbootstrap/blob/master/pmb/helpers/cli.py#L22) and [`init`](https://github.com/postmarketOS/pmbootstrap/blob/master/pmb/config/init.py#L38)

I'm using a scheme non-compliant with the FHS for my home folder, it is un `/Users/$USER`. It's really good to sniff out bugs where software assumes `/home/`. Surprisingly, the first time such an issue happened to me.

In a more perverse way, it will affect FHS-compliant `/home/` users that will want to input a workdir using uppercase letters (e.g. /home/bob/TEMP/pmbootstrap), where it will disregard uppercasing.