### PR TITLE
Update musl-armhf to r10.

### DIFF
--- a/aports/musl-armhf/APKBUILD
+++ b/aports/musl-armhf/APKBUILD
@@ -3,7 +3,7 @@
 
 pkgname=musl-armhf
 pkgver=1.1.16
-pkgrel=9
+pkgrel=10
 subpackages="musl-dev-armhf:package_dev"
 
 _arch="armhf"
@@ -46,5 +46,5 @@ package_dev() {
     done
 }
 
-sha512sums="865478e9ed9b97e8cedbe18cecb72611fd777c0fa45eebc67eae818084d0a3a5a85c6f37be5a874f48a8dcbb8c51ed4ceef6b33257215358e30ecddbb415c4b8  musl-1.1.16-r9-armhf.apk
-b6db9a9697b7bca35052cf5a247f2250d4e134f259584d98a48157c996c319e1e3d682b0cd68b90a86f5ea04eff4c2134f79be7aaff3d1b077934d4e45164e1d  musl-dev-1.1.16-r9-armhf.apk"
+sha512sums="2bebf6dfabb37d564a7fa9f0b2d0cc0d11c25880ee15aa8a0b63b03782d076047282752c37a88ca035bb3f2c3d9cd48f359e67cd11957f305fb8f59a641f3319  musl-dev-1.1.16-r10-armhf.apk
+31d68ab89f90da5315bae6302a768e687763601ae01cdf2258d85490dad18018872f316ee0e17e748779f64d1582dbc76f4c0b9b2370bdca8cfb1ff44df8539b  musl-1.1.16-r10-armhf.apk"


### PR DESCRIPTION
r9 no longer appears to be available on the mirrors.

The build with r10 is still running so I haven't confirmed if this breaks anything yet.