### PR TITLE
Support relative path for initializing config

### DIFF
--- a/pmb/config/init.py
+++ b/pmb/config/init.py
@@ -38,8 +38,8 @@ def init(args):
     # Work folder
     logging.info("Location of the 'work' path. Multiple chroots (native,"
                  " device arch, device rootfs) will be created in there.")
-    cfg["pmbootstrap"]["work"] = pmb.helpers.cli.ask(args, "Work path",
-                                                     None, args.work, False)
+    cfg["pmbootstrap"]["work"] = os.path.expanduser(pmb.helpers.cli.ask(args, "Work path",
+                                                    None, args.work, False))
     os.makedirs(cfg["pmbootstrap"]["work"], 0o700, True)
 
     # Parallel job count


### PR DESCRIPTION
Previously, if you passed something like ~/build to the init function
for work directory, it would create a directory, .\~/ in the current
working directory instead of resolving ~/ to the user's home directory.
This also allows using ../ to specify a path.