### PR TITLE
Fix red screen bug in hammerhead

### DIFF
--- a/aports/device-lg-hammerhead/APKBUILD
+++ b/aports/device-lg-hammerhead/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=device-lg-hammerhead
 pkgver=1
-pkgrel=1
+pkgrel=2
 pkgdesc="Google Nexus 5"
 url="https://github.com/postmarketOS"
 arch="noarch"
@@ -27,7 +27,7 @@ package() {
 		"$pkgdir"/etc/profile.d/00-$pkgname.sh
 }
 
-sha512sums="d9b34cde62f1de25a8635012ce1cc3a623a238ffb2237c997b74645d4e0df98f98f589c1f9c9f8d2519718d9345dee24b969b6efaa3533e5928a69272d9d997f  deviceinfo
+sha512sums="01a20f5286444b5d9616ddc541a84bc32a7c7f51a4b56e1015adcea5b238197c95863f68b783e06f83f423be2aeaff73f70ccc041da85b8a7987591cf97b94f4  deviceinfo
 8590967fa10388a890fdfafdb1070b9ab22dc89e06a3a8834806c772191e3b67de7b914b0d68e5ddf581cee715cb90f3f24abcb8762c415ff328c6da23e55d52  initfs-hook.sh
 ee25f3d0377f027d108593eb7953b8db49d7f05a5c36a0c8ca7e7849d15e3c217bc1ac97d77a66e28d2db4b81c0f50b905639911276da40321d2b6cca7f797df  90-android-touch-dev.rules
 c3d0182161c33047e0af4fd7cc557037e10380896a771446f055a13813e50e4e6c9d5992de7b275a8373a053cca02cb96bcb50c732709a2e9909f903b5fba249  profile.sh"

--- a/aports/device-lg-hammerhead/deviceinfo
+++ b/aports/device-lg-hammerhead/deviceinfo
@@ -26,3 +26,5 @@ deviceinfo_flash_offset_tags="0x02700000"
 deviceinfo_flash_cmdline="console=ttyHSL0,115200,n8 androidboot.hardware=hammerhead user_debug=31 maxcpus=2 msm_watchdog_v2.enable=1"
 deviceinfo_flash_pagesize="2048"
 
+# Weston red screen workaround (see issue #54)
+deviceinfo_weston_pixman_type="2"

--- a/aports/postmarketos-base/APKBUILD
+++ b/aports/postmarketos-base/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=postmarketos-base
 pkgver=1
-pkgrel=7
+pkgrel=8
 pkgdesc="Meta package for minimal postmarketos base"
 url="https://github.com/postmarketOS"
 arch="noarch"
@@ -21,6 +21,6 @@ package() {
 	install -D -m644 "$srcdir"/sudoers \
 		"$pkgdir"/etc/sudoers.d/postmarketos
 }
-sha512sums="d763c73c42795c05d28eeebfb6ef21e2c9706849331c485dbbf1ec7ea4f95cbeed4f6f615f5815f5a7acb9e0d30232cc7fe38c982ce1c7c4c8dfe8fabfe783ca  profile.sh
+sha512sums="149a3b87c6698814998e13afad6719df49dbf6b0556ad82cc040ee63da92a17ee4279408550b3ba7793dcf13cf212fbf9690b727d338414be45a3585c3265769  profile.sh
 0f4dcb493503081e0045b768bc81bb41096fdb5a340c4b5f23e7954f2bac7fd723ee00470bef400786725ab143bcc53e51607f28370c0c2533cbba623a5d9b13  weston.ini
 c6de3b44bc45b9f9c641a7e34c69a481ee39b99ac0251cd28f2b3aae49c1a8d1ca448f4936b7942b1a8b8f7c18a5415c938098765ed8cf08456543800160e64b  sudoers"

--- a/aports/postmarketos-base/profile.sh
+++ b/aports/postmarketos-base/profile.sh
@@ -1,5 +1,7 @@
 export DISPLAY=:0
 
+. /etc/deviceinfo
+
 if test -z "${XDG_RUNTIME_DIR}"; then
 	# https://wayland.freedesktop.org/building.html
 	export XDG_RUNTIME_DIR=/tmp/$(id -u)-runtime-dir
@@ -11,10 +13,15 @@ if test -z "${XDG_RUNTIME_DIR}"; then
 	# Weston autostart on tty1 (Autologin on tty1 is enabled in
 	# /etc/inittab by postmarketos-base post-install.hook)
 	if [ $(tty) = "/dev/tty1" ]; then
+        WESTON_OPTS="--backend=fbdev-backend.so"
+        if test -n "${deviceinfo_weston_pixman_type}"; then
+            WESTON_OPTS="${WESTON_OPTS} --pixman-type=${deviceinfo_weston_pixman_type}"
+        fi
+
 		udevadm trigger
 		udevadm settle
 		(sleep 2; postmarketos-demos) &
-		weston --backend=fbdev-backend.so >/tmp/weston.log 2>&1
+		weston ${WESTON_OPTS} >/tmp/weston.log 2>&1
 
 		# In case of failure, restart after 1s
 		sleep 1


### PR DESCRIPTION
Adds a new variable to deviceinfo that is used when weston is run