### PR TITLE
Fixed typo in new boot.img flasher

### DIFF
--- a/pmb/config/__init__.py
+++ b/pmb/config/__init__.py
@@ -209,7 +209,7 @@ flashers = {
                 {
                     "list_devices": [["fastboot", "devices", "-l"]],
                     "flash_system": [["fastboot", "flash", "system", "$IMAGE"]],
-                    "flash_kernel": [["fastboot", "flash" "boot", "$BOOT/boot.img-$FLAVOR"]],
+                    "flash_kernel": [["fastboot", "flash", "boot", "$BOOT/boot.img-$FLAVOR"]],
                     "boot": [["fastboot",
                               "--kernel-offset", "$OFFSET_KERNEL",
                               "--ramdisk-offset", "$OFFSET_RAMDISK",


### PR DESCRIPTION
This fixes a typo in the implementation for #35 