### PR TITLE
Added flavor to the flash_system command for consistency

### DIFF
--- a/pmb/flasher/frontend.py
+++ b/pmb/flasher/frontend.py
@@ -73,7 +73,6 @@ def list_flavors(args):
 
 def system(args):
     # Generate system image, install flasher
-    flavor = parse_flavor_arg(args)
     img_path = "/home/user/rootfs/" + args.device + ".img"
     if not os.path.exists(args.work + "/chroot_native" + img_path):
         setattr(args, "sdcard", None)
@@ -82,7 +81,7 @@ def system(args):
 
     # Run the flasher
     logging.info("(native) flash system image")
-    pmb.flasher.run(args, "flash_system", flavor)
+    pmb.flasher.run(args, "flash_system")
 
 
 def list_devices(args):

--- a/pmb/flasher/frontend.py
+++ b/pmb/flasher/frontend.py
@@ -73,6 +73,7 @@ def list_flavors(args):
 
 def system(args):
     # Generate system image, install flasher
+    flavor = parse_flavor_arg(args)
     img_path = "/home/user/rootfs/" + args.device + ".img"
     if not os.path.exists(args.work + "/chroot_native" + img_path):
         setattr(args, "sdcard", None)
@@ -81,7 +82,7 @@ def system(args):
 
     # Run the flasher
     logging.info("(native) flash system image")
-    pmb.flasher.run(args, "flash_system")
+    pmb.flasher.run(args, "flash_system", flavor)
 
 
 def list_devices(args):

--- a/pmb/flasher/run.py
+++ b/pmb/flasher/run.py
@@ -20,7 +20,7 @@ import pmb.flasher
 import pmb.chroot.initfs
 
 
-def run(args, action, flavor):
+def run(args, action, flavor=None):
     pmb.flasher.init(args)
 
     # Verify action
@@ -39,7 +39,7 @@ def run(args, action, flavor):
     # Variable setup
     vars = {
         "$BOOT": "/mnt/rootfs_" + args.device + "/boot",
-        "$FLAVOR": flavor,
+        "$FLAVOR": flavor if flavor is not None else "",
         "$IMAGE": "/home/user/rootfs/" + args.device + ".img",
         "$KERNEL_CMDLINE": cmdline,
         "$OFFSET_KERNEL": args.deviceinfo["flash_offset_kernel"],


### PR DESCRIPTION
The changes in flash_kernel broke the flash_system command (Issue #133). This makes the flavor argument optional for flasher.run()