### PR TITLE
[i9070][i9100] Build kernels natively

### DIFF
--- a/aports/busybox-static-aarch64/APKBUILD
+++ b/aports/busybox-static-aarch64/APKBUILD
@@ -1,0 +1,29 @@
+# Automatically generated aport, do not edit!
+# Generator: pmbootstrap aportgen busybox-static-aarch64
+
+pkgname=busybox-static-aarch64
+pkgver=1.26.2
+pkgrel=8
+
+_arch="aarch64"
+_mirror="https://nl.alpinelinux.org/alpine/"
+
+url="http://busybox.net"
+license="GPL2"
+arch="all"
+options="!check !strip"
+pkgdesc="Statically linked Busybox for $_arch"
+_target="$(arch_to_hostspec $_arch)"
+
+source="
+    busybox-static-$pkgver-r$pkgrel-$_arch.apk::$_mirror/edge/main/$_arch/busybox-static-$pkgver-r$pkgrel.apk
+"
+
+package() {
+    mkdir -p "$pkgdir/usr/$_target"
+    cd "$pkgdir/usr/$_target"
+    tar -xf $srcdir/busybox-static-$pkgver-r$pkgrel-$_arch.apk
+    rm .PKGINFO .SIGN.*
+}
+
+sha512sums="7daaafd1c8a8b6cca2dfc92bd57cb06e5e411027c2d6f7de8af735669b0c2e00c232331e9785f7e1a717fcc182b4e39f1906ee62b64579fa9a29cdff670b1549  busybox-static-1.26.2-r8-aarch64.apk"

--- a/aports/busybox-static-armhf/APKBUILD
+++ b/aports/busybox-static-armhf/APKBUILD
@@ -1,0 +1,29 @@
+# Automatically generated aport, do not edit!
+# Generator: pmbootstrap aportgen busybox-static-armhf
+
+pkgname=busybox-static-armhf
+pkgver=1.26.2
+pkgrel=8
+
+_arch="armhf"
+_mirror="https://nl.alpinelinux.org/alpine/"
+
+url="http://busybox.net"
+license="GPL2"
+arch="all"
+options="!check !strip"
+pkgdesc="Statically linked Busybox for $_arch"
+_target="$(arch_to_hostspec $_arch)"
+
+source="
+    busybox-static-$pkgver-r$pkgrel-$_arch.apk::$_mirror/edge/main/$_arch/busybox-static-$pkgver-r$pkgrel.apk
+"
+
+package() {
+    mkdir -p "$pkgdir/usr/$_target"
+    cd "$pkgdir/usr/$_target"
+    tar -xf $srcdir/busybox-static-$pkgver-r$pkgrel-$_arch.apk
+    rm .PKGINFO .SIGN.*
+}
+
+sha512sums="099c47767ed7f86f6a106afaa8b6e8dc33af4c7c7803d84a576f6640370bc52c995d1a65c5734337882e3452f2c79ebe0809b3120a7582f529f3d036f44c0b65  busybox-static-1.26.2-r8-armhf.apk"

--- a/aports/linux-samsung-i9070/APKBUILD
+++ b/aports/linux-samsung-i9070/APKBUILD
@@ -13,10 +13,6 @@
 # Kernel config changes, based on: arch/arm/configs/janice_defconfig
 # - enable devtmpfs (needed for udev -> touch support in weston)
 
-# This must be built in the target chroot, so busybox.static can
-# be used.
-_pmb_build_in_native_chroot="false"
-
 _vendor=samsung
 _flavor=samsung-i9070
 _hash="ac7219c4b8dcec7bc5a598d42c6be0db4aa36332"
@@ -28,13 +24,13 @@ case $pkgver in
 	*.*.*)  _kernver=${pkgver%.*};;
 	*.*) _kernver=$pkgver;;
 esac
-pkgrel=1
+pkgrel=2
 arch="armhf"
 pkgdesc="Samsung Galaxy S Advance kernel from Epirex"
 url="https://github.com/Epirex/Samsung_STE_Kernel"
 depends="postmarketos-mkinitfs"
 makedepends="perl sed installkernel bash gmp-dev bc linux-headers elfutils-dev
-findutils busybox-static"
+findutils busybox-static-armhf"
 options="!strip !check !tracedeps"
 install=
 source="
@@ -79,7 +75,8 @@ prepare() {
 
 	# Use Alpine's busybox.static instead of the pre-compiled busybox shipped
 	# with the source
-	cp -v /bin/busybox.static "$ksrcdir"/usr/u8500_initramfs_files/busybox
+	cp -v /usr/$(arch_to_hostspec $arch)/bin/busybox.static \
+		"$ksrcdir"/usr/u8500_initramfs_files/busybox
 
 	# do not use ramdisk.cpio and ramdisk-recovery.cpio, always use
 	# the initramfs from the kernel2 partition ("isorec"), so we can build

--- a/aports/linux-samsung-i9100/APKBUILD
+++ b/aports/linux-samsung-i9100/APKBUILD
@@ -13,10 +13,6 @@
 # - change compression from CONFIG_KERNEL_LZMA=y to
 #	CONFIG_KERNEL_GZIP=y (so it works with busybox)
 
-# This must be built in the target chroot, so busybox.static can
-# be used.
-_pmb_build_in_native_chroot="false"
-
 _vendor=samsung
 _flavor=samsung-i9100
 _hash="349a3e91e76d17e67ef6213e1f6712e700695631"
@@ -28,13 +24,13 @@ case $pkgver in
 	*.*.*)  _kernver=${pkgver%.*};;
 	*.*) _kernver=$pkgver;;
 esac
-pkgrel=5
+pkgrel=6
 arch="armhf"
 pkgdesc="Samsung Galaxy SII kernel from LineageOS"
 url="https://github.com/LineageOS/android_kernel_samsung_smdk4412"
 depends="postmarketos-mkinitfs"
 makedepends="perl sed installkernel bash gmp-dev bc linux-headers elfutils-dev
-findutils busybox-static"
+findutils busybox-static-armhf"
 options="!strip !check !tracedeps"
 install=
 source="
@@ -78,7 +74,8 @@ prepare() {
 
 	# Use Alpine's busybox.static instead of the pre-compiled busybox shipped
 	# with the source
-	cp -v /bin/busybox.static "$ksrcdir"/usr/galaxys2_initramfs_files/busybox
+	cp -v /usr/$(arch_to_hostspec $arch)/bin/busybox.static \
+		"$ksrcdir"/usr/galaxys2_initramfs_files/busybox
 
 	# do not use ramdisk.cpio and ramdisk-recovery-device.cpio, always use
 	# the initramfs from the recovery partition ("isorec"), so we can build

--- a/pmb/aportgen/__init__.py
+++ b/pmb/aportgen/__init__.py
@@ -21,6 +21,7 @@ import logging
 import pmb.aportgen.binutils
 import pmb.aportgen.musl
 import pmb.aportgen.gcc
+import pmb.aportgen.busybox_static
 import pmb.helpers.git
 
 
@@ -38,6 +39,8 @@ def generate(args, pkgname):
         pmb.aportgen.musl.generate(args, pkgname)
     elif pkgname.startswith("gcc-"):
         pmb.aportgen.gcc.generate(args, pkgname)
+    elif pkgname.startswith("busybox-static-"):
+        pmb.aportgen.busybox_static.generate(args, pkgname)
     else:
         raise ValueError("No generator available for " + pkgname + "!")
 

--- a/pmb/aportgen/busybox_static.py
+++ b/pmb/aportgen/busybox_static.py
@@ -1,0 +1,100 @@
+"""
+Copyright 2017 Oliver Smith
+
+This file is part of pmbootstrap.
+
+pmbootstrap is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+pmbootstrap is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with pmbootstrap.  If not, see <http://www.gnu.org/licenses/>.
+"""
+import glob
+import os
+import pmb.helpers.run
+import pmb.aportgen.core
+import pmb.parse.apkindex
+import pmb.chroot.apk
+import pmb.chroot.apk_static
+
+
+def generate(args, pkgname):
+    # Install busybox-static in chroot (so we have the APKINDEX and verified
+    # apks)
+    arch = pkgname.split("-")[2]
+    apkindex = pmb.chroot.apk_static.download(args, "APKINDEX.tar.gz")
+    pmb.chroot.apk.install(args, ["busybox-static"], "buildroot_" + arch)
+
+    # Parse version from APKINDEX
+    package_data = pmb.parse.apkindex.read(args, "busybox", apkindex)
+    version = package_data["version"]
+    pkgver = version.split("-r")[0]
+    pkgrel = version.split("-r")[1]
+
+    # Copy the apk file to the distfiles cache
+    pattern = (args.work + "/cache_apk_" + arch + "/busybox-static-" +
+               version + ".*.apk")
+    glob_result = glob.glob(pattern)
+    if not len(glob_result):
+        raise RuntimeError("Could not find aport " + pattern + "!"
+                           " Update your aports_upstream git repo"
+                           " to the latest version, delete your http cache"
+                           " (pmbootstrap zap -hc) and try again.")
+    path = glob_result[0]
+    path_target = (args.work + "/cache_distfiles/busybox-static-" +
+                   version + "-" + arch + ".apk")
+    if not os.path.exists(path_target):
+        pmb.helpers.run.user(args, ["cp", path, path_target])
+
+    # Hash the distfile
+    hashes = pmb.chroot.user(args, ["sha512sum",
+                                    "busybox-static-" + version + "-" + arch + ".apk"],
+                             "buildroot_" + arch, working_dir="/var/cache/distfiles",
+                             return_stdout=True)
+
+    # Write the APKBUILD
+    pmb.helpers.run.user(args, ["mkdir", "-p", args.work + "/aportgen"])
+    with open(args.work + "/aportgen/APKBUILD", "w", encoding="utf-8") as handle:
+        # Variables
+        handle.write("# Automatically generated aport, do not edit!\n"
+                     "# Generator: pmbootstrap aportgen " + pkgname + "\n"
+                     "\n"
+                     "pkgname=" + pkgname + "\n"
+                     "pkgver=" + pkgver + "\n"
+                     "pkgrel=" + pkgrel + "\n"
+                     "\n"
+                     "_arch=\"" + arch + "\"\n"
+                     "_mirror=\"" + args.mirror_alpine + "\"\n"
+                     )
+        # Static part
+        static = """
+            url="http://busybox.net"
+            license="GPL2"
+            arch="all"
+            options="!check !strip"
+            pkgdesc="Statically linked Busybox for $_arch"
+            _target="$(arch_to_hostspec $_arch)"
+
+            source="
+                busybox-static-$pkgver-r$pkgrel-$_arch.apk::$_mirror/edge/main/$_arch/busybox-static-$pkgver-r$pkgrel.apk
+            "
+
+            package() {
+                mkdir -p "$pkgdir/usr/$_target"
+                cd "$pkgdir/usr/$_target"
+                tar -xf $srcdir/busybox-static-$pkgver-r$pkgrel-$_arch.apk
+                rm .PKGINFO .SIGN.*
+            }
+        """
+        for line in static.split("\n"):
+            handle.write(line[12:] + "\n")
+
+        # Hashes
+        handle.write("sha512sums=\"" + hashes.rstrip() + "\"\n")

--- a/pmb/build/autodetect.py
+++ b/pmb/build/autodetect.py
@@ -47,7 +47,7 @@ def suffix(args, apkbuild, carch):
     pkgname = apkbuild["pkgname"]
     if pkgname.endswith("-repack"):
         return "native"
-    if args.cross and apkbuild["_pmb_build_in_native_chroot"] != "false":
+    if args.cross:
         for pattern in pmb.config.build_cross_native:
             if fnmatch.fnmatch(pkgname, pattern):
                 return "native"

--- a/pmb/config/__init__.py
+++ b/pmb/config/__init__.py
@@ -143,7 +143,6 @@ apkbuild_attributes = {
     "_flavor": {"array": False},
     "_device": {"array": False},
     "_kernver": {"array": False},
-    "_pmb_build_in_native_chroot": {"array": False},
 
     # mesa
     "_llvmver": {"array": False},

--- a/test/test_aportgen.py
+++ b/test/test_aportgen.py
@@ -48,7 +48,7 @@ def test_aportgen(args):
     pkgnames = []
     for arch in pmb.config.build_device_architectures:
         # gcc twice, so the output folder already exists -> different code path
-        for pkgname in ["binutils", "musl", "gcc", "gcc"]:
+        for pkgname in ["binutils", "musl", "busybox-static", "gcc", "gcc"]:
             pkgnames.append(pkgname + "-" + arch)
     for pkgname in pkgnames:
         pmb.aportgen.generate(args, pkgname)


### PR DESCRIPTION
This PR removes the need of the `_pmb_build_in_native_chroot` variable inside the APKBUILDs. Instead of compiling inside a native `armhf` chroot, to get Alpine's `busybox-static` binary, the `armhf` version gets installed inside the `x86_64` chroot. Just like `musl-armhf`.

This speeds up compiling a lot and removes the need for the `_pmb_build_in_native_chroot` hack, while still using Alpine's busybox instead of the pre-compiled blob shipped with the kernel sources.