### PR TITLE
[RX51] Account for uInitrd filename change in u-boot script

### DIFF
--- a/aports/device-nokia-rx51/APKBUILD
+++ b/aports/device-nokia-rx51/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=device-nokia-rx51
 pkgver=1
-pkgrel=5
+pkgrel=6
 pkgdesc="Nokia N900"
 url="https://github.com/postmarketOS"
 arch="noarch"
@@ -27,5 +27,5 @@ package() {
 }
 
 sha512sums="7eb602ae1f6002a928f2a5cf12edf21ffe76e6e378907f73da6b6df98016bf5f3e256f93a4187a354069631f283a2f0769b5acf05445e42d8f630966b36dfa6b  deviceinfo
-011e85537f497c2888f876a63bec13e3a2853a5047a0692515d6108cee2a2b90e70fb234f9c0e67a11d64abd3a15cade0864d725548722df910d6d1cbb1216e4  uboot-script.cmd
+dbbab330a9a136ec22c52bf6376049d6598c01e784f9a8a1da144f56621a086c5e52a10afac5c067c9ca921354d76babeea81e0eac2d407a1aae448e7ddee3b4  uboot-script.cmd
 3d55e34b95791636e44a5f41754f3d0de039dbba41f7a556d43a95c9e64afcfa930046b4b96b40020b6f196096ffba93514682927e32fa4488686fdd19c6da5a  backlight-enable.sh"

--- a/aports/device-nokia-rx51/uboot-script.cmd
+++ b/aports/device-nokia-rx51/uboot-script.cmd
@@ -4,7 +4,7 @@ setenv mmctype ext2
 setenv setup_omap_atag 1
 setenv bootargs init=/init.sh rw console=tty0 console=tty02 omapfb_vram=7M omapfb.mode=lcd:848x480-16 nokia-modem.pm=0
 setenv mmckernfile /uImage
-setenv mmcinitrdfile /uInitrd
+setenv mmcinitrdfile /uInitrd-nokia-rx51
 setenv mmcscriptfile
 echo Loading initramfs
 run initrdload


### PR DESCRIPTION
The uInitrd filename is appended with 'flavor' so, for example, with the
rx-51 the generated file is named 'uInitrd-nokia-rx51'. This corrects
the rx51's u-boot script to account for this change in filename.

This fixes #152 