### PR TITLE
[RX51] Set keyboard layout for weston

### DIFF
--- a/aports/device-nokia-rx51/APKBUILD
+++ b/aports/device-nokia-rx51/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=device-nokia-rx51
 pkgver=1
-pkgrel=8
+pkgrel=9
 pkgdesc="Nokia N900"
 url="https://github.com/postmarketOS"
 arch="noarch"
@@ -33,7 +33,7 @@ package() {
                 "$pkgdir"/etc/acpi.map
 }
 
-sha512sums="90239ee58c3eadd08ab171ad8a73a1be1ea1416bbe8a29bc8b959831bbe23bbb93a59f8dff8ea8780578c1238b9e89859c4d427ac1970ac7b16a44c3293ba747  deviceinfo
+sha512sums="24dadbf6971dc3e32b73f6419b7add105ef432615c9664bca4ef872d4ccda2af0cd399748d84a103c106b73e83eebc97387f22efcb96cef075a21223878152c6  deviceinfo
 36fdcdc32e75ad82402d7f8dc6ec5879002513b3552ae4cf755df52f2c3df7b12c3ab0aae8ea8207a7fa22240b88f8098fd283298d08f923f9b07b7964289b83  uboot-script.cmd
 3d55e34b95791636e44a5f41754f3d0de039dbba41f7a556d43a95c9e64afcfa930046b4b96b40020b6f196096ffba93514682927e32fa4488686fdd19c6da5a  backlight-enable.sh
 98c554a709d6e8da5835bd792d833355d830fca1cfea12ec7fe4f41d1d1126389c51a8a392a7f94093473c19263cc6846cc40d7e179c2facf12db2d68ff923f9  90-touchscreen-dev.rules

--- a/aports/device-nokia-rx51/deviceinfo
+++ b/aports/device-nokia-rx51/deviceinfo
@@ -15,5 +15,7 @@ deviceinfo_flash_methods="0xFFFF"
 deviceinfo_generate_legacy_uboot_initfs="true"
 deviceinfo_arch="armhf"
 
+# Weston Config
 deviceinfo_weston_core_modules="xwayland.so"
-
+deviceinfo_weston_keymap_rules="evdev"
+deviceinfo_weston_keymap_model="nokiarx51"


### PR DESCRIPTION
This configured weston.ini to include the appropriate keyboard layout
for the RX51, so now we can enter numbers in weston!

@MartijnBraam, FYI