### PR TITLE
Install: Small improvements (Fix #162, Close #215)

### DIFF
--- a/pmb/flasher/frontend.py
+++ b/pmb/flasher/frontend.py
@@ -84,8 +84,8 @@ def system(args):
     # Generate system image, install flasher
     img_path = "/home/user/rootfs/" + args.device + ".img"
     if not os.path.exists(args.work + "/chroot_native" + img_path):
-        setattr(args, "sdcard", None)
-        pmb.install.install(args, False)
+        raise RuntimeError("The system image has not been generated yet,"
+                           " please run 'pmbootstrap install' first.")
     pmb.flasher.init(args)
 
     # Run the flasher

--- a/pmb/install/format.py
+++ b/pmb/install/format.py
@@ -37,6 +37,7 @@ def format_and_mount_root(args):
     if args.full_disk_encryption:
         logging.info("(native) format " + device + " (root, luks), mount to " +
                      mountpoint)
+        logging.info(" *** SET FULL DISK ENCRYPTION PASSWORD ***")
         pmb.chroot.root(args, ["cryptsetup", "luksFormat", "--use-urandom",
                                "--cipher", args.cipher, "-q", device], log=False)
         pmb.chroot.root(args, ["cryptsetup", "luksOpen", device,

--- a/pmb/install/install.py
+++ b/pmb/install/install.py
@@ -67,6 +67,7 @@ def set_user_password(args):
     """
     Loop until the passwords for user and root have been changed successfully.
     """
+    logging.info(" *** SET LOGIN PASSWORD FOR: 'user' ***")
     suffix = "rootfs_" + args.device
     while True:
         try:

--- a/pmb/install/install.py
+++ b/pmb/install/install.py
@@ -78,7 +78,7 @@ def set_user_password(args):
             pass
 
 
-def install(args, show_flash_msg=True):
+def install(args):
     # Install required programs in native chroot
     logging.info("*** (1/5) PREPARE NATIVE CHROOT ***")
     pmb.chroot.apk.install(args, pmb.config.install_native_packages,
@@ -122,32 +122,32 @@ def install(args, show_flash_msg=True):
     fix_mount_folders(args)
     pmb.chroot.shutdown(args, True)
 
-    # Flash to target device
+    # Kernel flash information
     logging.info("*** (5/5) FLASHING TO DEVICE ***")
-    if show_flash_msg:
-        logging.info("Run the following to flash your installation to the"
-                     " target device:")
-        logging.info("* pmbootstrap flasher flash_kernel")
-        logging.info("  Flashes the kernel + initramfs to your device:")
-        logging.info(
-            "  " +
-            args.work +
-            "/chroot_rootfs_" +
-            args.device +
-            "/boot")
-        method = args.deviceinfo["flash_methods"]
-        if (method in pmb.config.flashers and "boot" in
-                pmb.config.flashers[method]["actions"]):
-            logging.info("  (NOTE: " + method + " also supports booting"
-                         " the kernel/initramfs directly without flashing."
-                         " Use 'pmbootstrap flasher boot' to do that.)")
+    logging.info("Run the following to flash your installation to the"
+                 " target device:")
+    logging.info("* pmbootstrap flasher flash_kernel")
+    logging.info("  Flashes the kernel + initramfs to your device:")
+    logging.info("  " + args.work + "/chroot_rootfs_" + args.device +
+                 "/boot")
+    method = args.deviceinfo["flash_methods"]
+    if (method in pmb.config.flashers and "boot" in
+            pmb.config.flashers[method]["actions"]):
+        logging.info("  (NOTE: " + method + " also supports booting"
+                     " the kernel/initramfs directly without flashing."
+                     " Use 'pmbootstrap flasher boot' to do that.)")
 
-        if not args.sdcard:
-            logging.info("* pmbootstrap flasher flash_system")
-            logging.info("  Flashes the system image, that has been"
-                         " generated to your device:")
-            logging.info("  " + args.work + "/chroot_native/home/user/rootfs/" +
-                         args.device + ".img")
-            logging.info("  (NOTE: This file has a partition table,"
-                         " which contains one currently unused boot"
-                         " partition, and the root partition.)")
+    # System flash information
+    if not args.sdcard:
+        logging.info("* pmbootstrap flasher flash_system")
+        logging.info("  Flashes the system image, that has been"
+                     " generated to your device:")
+        logging.info("  " + args.work + "/chroot_native/home/user/rootfs/" +
+                     args.device + ".img")
+        logging.info("  (NOTE: This file has a partition table,"
+                     " which contains a boot- and root subpartition.)")
+
+    # Export information
+    logging.info("* If the above steps do not work, you can also create"
+                 " symlinks to the generated files with 'pmbootstrap flasher"
+                 " export <target_dir>' and flash outside of pmbootstrap.")


### PR DESCRIPTION
* #162: When `flasher flash_system` runs, do not try to generate the system image anymore, when it does not exist. That failed previously, because the `--add` parameter was not available. Instead of simply adding it, it throws a meaningful error now. Because otherwise `--add` would do the expected thing only when the system image is missing - otherwise it would be ignored.
* #215: Write explicitly which passwords the user will be configuring
* Added information about `pmbootstrap export` after the installation.