### PR TITLE
Fix #226: Building busybox recurses forever.

### DIFF
--- a/pmb/build/init.py
+++ b/pmb/build/init.py
@@ -33,7 +33,8 @@ def init(args, suffix="native"):
         return
 
     # Initialize chroot, install packages
-    pmb.chroot.apk.install(args, pmb.config.build_packages, suffix)
+    pmb.chroot.apk.install(args, pmb.config.build_packages, suffix,
+                           build=False)
 
     # Fix permissions
     pmb.chroot.root(args, ["chmod", "-R", "a+rw",

--- a/pmb/build/package.py
+++ b/pmb/build/package.py
@@ -66,7 +66,8 @@ def package(args, pkgname, carch, force=False, buildinfo=False):
                                       "g++-" + carch_buildenv,
                                       "ccache-cross-symlinks"])
         if cross == "distcc":
-            pmb.chroot.apk.install(args, ["distcc"], suffix=suffix)
+            pmb.chroot.apk.install(args, ["distcc"], suffix=suffix,
+                                   build=False)
             pmb.chroot.distccd.start(args, carch_buildenv)
 
     # Configure abuild.conf


### PR DESCRIPTION
If you really want to build busybox, I recommend turning the
"timestamp based rebuilds" feature off, otherwise it will build
for all architectures all the time whenever you change something,
even if you do not increase the version number (that's the idea
of that feature). This is, because busybox is a dependency for
basiscally everything, so it must get updated whenever you install
something, in case it was out of date.

It is easier to simply rename the package.