### PR TITLE
Enable syslog on boot

### DIFF
--- a/aports/postmarketos-base/APKBUILD
+++ b/aports/postmarketos-base/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=postmarketos-base
 pkgver=2
-pkgrel=1
+pkgrel=2
 pkgdesc="Meta package for minimal postmarketos base"
 url="https://github.com/postmarketOS"
 arch="noarch"

--- a/aports/postmarketos-base/postmarketos-base.post-install
+++ b/aports/postmarketos-base/postmarketos-base.post-install
@@ -6,7 +6,7 @@
 for service in devfs dmesg; do
 	rc-update -q add $service sysinit
 done
-for service in hwclock modules sysctl hostname bootmisc wpa_supplicant wifi-handler; do
+for service in hwclock modules sysctl hostname bootmisc wpa_supplicant wifi-handler syslog; do
 	rc-update -q add $service boot
 done
 for service in haveged sshd udev; do
@@ -48,3 +48,6 @@ if ! apk audit /etc | grep -q etc/motd; then
 		echo ''
 	} >/etc/motd
 fi
+
+# Enable syslog to SHM. Note: size is 4048KiB, which *should* be More Than Enough(TM) for all but the most chattiest of devices.
+sed s/=\"/=\""-C4048 "/  -i /etc/conf.d/syslog


### PR DESCRIPTION
This enables the busybox syslog implementation, which logs to
/var/log/messages, on boot. This is very helpful for debugging
applications which write to syslog (e.g. NetworkManager)