### PR TITLE
Add dtbtool package

### DIFF
--- a/aports/dtbtool/APKBUILD
+++ b/aports/dtbtool/APKBUILD
@@ -1,0 +1,22 @@
+pkgname=dtbtool
+pkgver=3
+pkgrel=1
+pkgdesc="dtbtool"
+url="https://github.com/LineageOS/android_device_qcom_common/tree/cm-14.1/dtbtool"
+arch="all"
+license="MIT"
+source="dtbtool.c::https://source.codeaurora.org/quic/la/device/qcom/common/plain/dtbtool/dtbtool.c?h=LA.BF64.1.2.1.c1_rb1.30 Makefile"
+options="!check"
+
+build() {
+	cd "$srcdir"
+	make
+}
+
+package() {
+	install -D -m755 "$srcdir"/dtbtool \
+		"$pkgdir"/usr/bin/dtbtool || return 1
+}
+sha512sums="ce5859df28d91c21288738a39c75aee609ae2632db7a93346719039f9bf3fcc42048aa5d799568bf5e577f59e9fefa18a340fb3d026b335086b4e3e9d85d56ed  dtbtool.c
+860d1c4af00beb091fdbb9a0491601f35bb1ef3ce1846f0f250d4b973919472f7cb414b9a7d0b1d5ad2597fd7ae7428cd619e81db8971929a352a666d9f8800b  Makefile"
+

--- a/aports/dtbtool/Makefile
+++ b/aports/dtbtool/Makefile
@@ -1,0 +1,14 @@
+CFLAGS=-O2 -g -Wall
+CC=gcc
+PROGNAME=dtbtool
+
+all: dtbtool
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $<
+
+dtbtool: dtbtool.o
+	$(CC) -g -o dtbtool dtbtool.o
+
+clean:
+	rm -f *.o dtbtool


### PR DESCRIPTION
Needed for packaging `dt.img` files (e.g. in Mozilla Flame)