### PR TITLE
Fix #282: '/bin/ash': Permission denied

### DIFF
--- a/pmb/config/init.py
+++ b/pmb/config/init.py
@@ -39,7 +39,8 @@ def ask_for_work_path(args):
         try:
             ret = os.path.expanduser(pmb.helpers.cli.ask(
                 args, "Work path", None, args.work, False))
-            os.makedirs(ret + "/chroot_native", 0o700, True)
+            os.makedirs(ret, 0o700, True)
+            os.makedirs(ret + "/chroot_native", 0o755, True)
             return ret
         except OSError:
             logging.fatal("ERROR: Could not create this folder, or write"


### PR DESCRIPTION
This was a regression from the improved input validation PR, which
created the chroot_native folder with the wrong permissions (to test
if we have write access to the work folder).

sjamaan found out, that this was the cause of the issue, and also
explained how to fix it, thanks a lot!

@MartijnBraam: please merge after reviewing, thanks!