### PR TITLE
Allow 'pmbootstrap menuconfig' without specifying "linux-"

### DIFF
--- a/pmb/build/menuconfig.py
+++ b/pmb/build/menuconfig.py
@@ -29,6 +29,13 @@ import pmb.parse
 
 
 def menuconfig(args, pkgname, arch):
+    if pkgname.startswith("linux-"):
+        pkgname_ = pkgname.split("linux-")[1]
+        logging.info("PROTIP: You can simply do 'pmbootstrap menuconfig " +
+                     pkgname_ + "'")
+    else:
+        pkgname = "linux-" + pkgname
+
     # Read apkbuild
     aport = pmb.build.find_aport(args, pkgname, False)
     if not aport:


### PR DESCRIPTION
We can allow both ways:
* `pmbootstrap menuconfig linux-motorola-titan`
* `pmbootstrap menuconfig motorola-titan`

The former will show a tip about the second
This also prevents users from running menuconfig on aports like
'device-motorola-titan' or 'mkbootimg'