### PR TITLE
Fix #271: properly resolve symlinks in all paths

### DIFF
--- a/pmb/build/other.py
+++ b/pmb/build/other.py
@@ -102,7 +102,7 @@ def aports_files_out_of_sync_with_git(args, package=None):
     # Filter out a specific package
     if package:
         ret = []
-        prefix = os.path.abspath(
+        prefix = os.path.realpath(
             pmb.build.other.find_aport(
                 args, package)) + "/"
         for file in aports_files_out_of_sync_with_git(args):
@@ -136,10 +136,10 @@ def aports_files_out_of_sync_with_git(args, package=None):
             working_dir=git_root, return_stdout=True)
 
         # Set absolute path, filter out aports files
-        aports_absolute = os.path.abspath(args.aports)
+        aports_absolute = os.path.realpath(args.aports)
         files = tracked.rstrip().split("\n") + untracked.rstrip().split("\n")
         for file in files:
-            file = os.path.abspath(git_root + "/" + file)
+            file = os.path.realpath(git_root + "/" + file)
             if file.startswith(aports_absolute):
                 ret.append(file)
     else:

--- a/pmb/challenge/build.py
+++ b/pmb/challenge/build.py
@@ -54,7 +54,7 @@ def build(args, apk_path):
     repo_diff = pmb.helpers.repo.diff(args, repo_before)
 
     # Diff the apk contents
-    staging_path = os.path.abspath(os.path.dirname(apk_path) + "/../")
+    staging_path = os.path.realpath(os.path.dirname(apk_path) + "/../")
     for file in repo_diff:
         file_staging = staging_path + "/" + file
         file_work = args.work + "/packages/" + file

--- a/pmb/chroot/zap.py
+++ b/pmb/chroot/zap.py
@@ -39,7 +39,7 @@ def zap(args):
         patterns += ["cache_http"]
 
     for pattern in patterns:
-        pattern = os.path.abspath(args.work + "/" + pattern)
+        pattern = os.path.realpath(args.work + "/" + pattern)
         matches = glob.glob(pattern)
         for match in matches:
             if pmb.helpers.cli.confirm(args, "Remove " + match + "?"):

--- a/pmb/helpers/file.py
+++ b/pmb/helpers/file.py
@@ -66,7 +66,7 @@ def symlink(args, file, link):
     """
     if os.path.exists(link):
         if (os.path.islink(link) and
-                os.path.abspath(os.readlink(link)) == os.path.abspath(file)):
+                os.path.realpath(os.readlink(link)) == os.path.realpath(file)):
             return
         raise RuntimeError("File exists: " + link)
     elif os.path.islink(link):

--- a/pmb/helpers/mount.py
+++ b/pmb/helpers/mount.py
@@ -25,7 +25,7 @@ def ismount(folder):
     Ismount() implementation, that works for mount --bind.
     Workaround for: https://bugs.python.org/issue29707
     """
-    folder = os.path.abspath(os.path.realpath(folder))
+    folder = os.path.realpath(os.path.realpath(folder))
     with open("/proc/mounts", "r") as handle:
         for line in handle:
             words = line.split()
@@ -86,7 +86,7 @@ def umount_all_list(prefix, source="/proc/mounts"):
     :returns: a list of folders, that need to be umounted
     """
     ret = []
-    prefix = os.path.abspath(prefix)
+    prefix = os.path.realpath(prefix)
     with open(source, "r") as handle:
         for line in handle:
             words = line.split()

--- a/test/test_apk_static.py
+++ b/test/test_apk_static.py
@@ -23,7 +23,7 @@ import glob
 import pytest
 
 # Import from parent directory
-pmb_src = os.path.abspath(os.path.join(os.path.dirname(__file__) + "/.."))
+pmb_src = os.path.realpath(os.path.join(os.path.dirname(__file__) + "/.."))
 sys.path.append(pmb_src)
 import pmb.chroot.apk_static
 import pmb.parse.apkindex

--- a/test/test_aport_in_sync_with_git.py
+++ b/test/test_aport_in_sync_with_git.py
@@ -21,7 +21,7 @@ import sys
 import pytest
 
 # Import from parent directory
-sys.path.append(os.path.abspath(
+sys.path.append(os.path.realpath(
     os.path.join(os.path.dirname(__file__) + "/..")))
 import pmb.build.other
 import pmb.chroot.apk
@@ -84,7 +84,7 @@ def out_of_sync_files(args):
 def test_aport_in_sync_with_git(args):
     aports = temp_aports_repo(args)
     ret_in_sync = []
-    ret_out_of_sync = [args.aports + "/main/alpine-base/APKBUILD"]
+    ret_out_of_sync = [os.path.realpath(args.aports + "/main/alpine-base/APKBUILD")]
 
     # In sync (no files changed)
     assert out_of_sync_files(args) == ret_in_sync

--- a/test/test_aportgen.py
+++ b/test/test_aportgen.py
@@ -22,7 +22,7 @@ import pytest
 import filecmp
 
 # Import from parent directory
-sys.path.append(os.path.abspath(
+sys.path.append(os.path.realpath(
     os.path.join(os.path.dirname(__file__) + "/..")))
 import pmb.aportgen
 import pmb.config

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -21,7 +21,7 @@ import sys
 import pytest
 
 # Import from parent directory
-sys.path.append(os.path.abspath(
+sys.path.append(os.path.realpath(
     os.path.join(os.path.dirname(__file__) + "/..")))
 import pmb.aportgen
 import pmb.config

--- a/test/test_build_is_necessary.py
+++ b/test/test_build_is_necessary.py
@@ -21,7 +21,7 @@ import sys
 import pytest
 
 # Import from parent directory
-sys.path.append(os.path.abspath(
+sys.path.append(os.path.realpath(
     os.path.join(os.path.dirname(__file__) + "/..")))
 import pmb.build.other
 import pmb.helpers.logging
@@ -73,7 +73,7 @@ def cache_files_out_of_sync(args, is_out_of_sync):
     new = []
     if is_out_of_sync:
         aport = pmb.build.other.find_aport(args, "hello-world")
-        new = [os.path.abspath(aport + "/APKBUILD")]
+        new = [os.path.realpath(aport + "/APKBUILD")]
     args.cache["aports_files_out_of_sync_with_git"] = new
 
 

--- a/test/test_challenge_apk.py
+++ b/test/test_challenge_apk.py
@@ -22,7 +22,7 @@ import pytest
 import tarfile
 
 # Import from parent directory
-sys.path.append(os.path.abspath(
+sys.path.append(os.path.realpath(
     os.path.join(os.path.dirname(__file__) + "/..")))
 import pmb.challenge.apk_file
 import pmb.config

--- a/test/test_challenge_apkindex.py
+++ b/test/test_challenge_apkindex.py
@@ -21,7 +21,7 @@ import sys
 import pytest
 
 # Import from parent directory
-sys.path.append(os.path.abspath(
+sys.path.append(os.path.realpath(
     os.path.join(os.path.dirname(__file__) + "/..")))
 import pmb.challenge.apkindex
 import pmb.config

--- a/test/test_challenge_build.py
+++ b/test/test_challenge_build.py
@@ -21,7 +21,7 @@ import sys
 import pytest
 
 # Import from parent directory
-sys.path.append(os.path.abspath(
+sys.path.append(os.path.realpath(
     os.path.join(os.path.dirname(__file__) + "/..")))
 import pmb.build.package
 import pmb.challenge.build

--- a/test/test_chroot_interactive_shell.py
+++ b/test/test_chroot_interactive_shell.py
@@ -24,7 +24,7 @@ def test_chroot_interactive_shell():
     """
     Open a shell with 'pmbootstrap chroot' and pass 'echo hello_world\n' as stdin.
     """
-    pmb_src = os.path.abspath(os.path.join(os.path.dirname(__file__) + "/.."))
+    pmb_src = os.path.realpath(os.path.join(os.path.dirname(__file__) + "/.."))
     os.chdir(pmb_src)
     ret = subprocess.check_output(["./pmbootstrap.py", "-q", "chroot"], timeout=300,
                                   input="echo hello_world\n", universal_newlines=True,

--- a/test/test_keys.py
+++ b/test/test_keys.py
@@ -23,7 +23,7 @@ import glob
 import filecmp
 
 # Import from parent directory
-sys.path.append(os.path.abspath(
+sys.path.append(os.path.realpath(
     os.path.join(os.path.dirname(__file__) + "/..")))
 import pmb.parse.apkindex
 import pmb.helpers.git

--- a/test/test_mount.py
+++ b/test/test_mount.py
@@ -20,7 +20,7 @@ import os
 import sys
 
 # Import from parent directory
-sys.path.append(os.path.abspath(
+sys.path.append(os.path.realpath(
     os.path.join(os.path.dirname(__file__) + "/..")))
 import pmb.helpers.mount
 

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -24,7 +24,7 @@ import time
 import logging
 
 # Import from parent directory
-pmb_src = os.path.abspath(os.path.join(os.path.dirname(__file__) + "/.."))
+pmb_src = os.path.realpath(os.path.join(os.path.dirname(__file__) + "/.."))
 sys.path.append(pmb_src)
 import pmb.build.package
 import pmb.helpers.logging

--- a/test/test_shell_escape.py
+++ b/test/test_shell_escape.py
@@ -21,7 +21,7 @@ import sys
 import pytest
 
 # Import from parent directory
-pmb_src = os.path.abspath(os.path.join(os.path.dirname(__file__) + "/.."))
+pmb_src = os.path.realpath(os.path.join(os.path.dirname(__file__) + "/.."))
 sys.path.append(pmb_src)
 import pmb.chroot.root
 import pmb.chroot.user

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -21,7 +21,7 @@ import sys
 import pytest
 
 # Import from parent directory
-sys.path.append(os.path.abspath(
+sys.path.append(os.path.realpath(
     os.path.join(os.path.dirname(__file__) + "/..")))
 import pmb.parse.apkindex
 import pmb.helpers.git


### PR DESCRIPTION
I've replaced all instances in the code of `os.path.abspath`
with `os.path.realpath`, as this does the same as `abspath`
plus resolving symlinks. Source: https://stackoverflow.com/a/40311142

### How to test this PR
* Create symlinks in the path to your work folder
* `pmbootstrap zap -p`
* `pmbootstrap install`
* Test if the timestamp based rebuilds feature still works: change a comment in `aports/main/hello-world/APKBUILD` and run `pmbootstrap install` again. The aport should get rebuilt and updated in the device rootfs chroot.