### PR TITLE
Increase minimal system image size by 15% to have some free space

### DIFF
--- a/pmb/install/install.py
+++ b/pmb/install/install.py
@@ -137,7 +137,7 @@ def install(args):
     for flavor in pmb.chroot.other.kernel_flavors_installed(args, suffix):
         pmb.chroot.initfs.build(args, flavor, suffix)
 
-    size_image = str(int(get_chroot_size(args)) + 50) + "M"
+    size_image = str(int(float(get_chroot_size(args)) * 1.15)) + "M"
     size_boot = str(int(get_chroot_boot_size(args)) + 5) + "M"
 
     # Finally set the user password


### PR DESCRIPTION
We need a better computation of the minimal partition size because right now it just computes the total required size using du (see [here](https://github.com/postmarketOS/pmbootstrap/blob/master/pmb/install/install.py#L48)) and simply adds 50MB to the root partition have some free space (see [here](https://github.com/postmarketOS/pmbootstrap/blob/master/pmb/install/install.py#L140)) and 5MB to the boot partition.

In this way we might end up with a partition with no space left because the ext4 partition has a default of 5% reserved blocks for root processes and also the filesystem metadata takes some place.

With this PR I changed the computation to add 15% of the size to the computed one, instead of the 50MB.

I did some tests with/without the change in this PR and I got these results:

with the addition of 50MB:

| img file size | boot partition size | root partition size | root filesystem (size/used/avail) |
|-|-|-|-|
| 333 | 19 | 313 | 296/249/**28** |
| 404 | 19 | 384 | 364/306/**35** |
| 598 | 19 | 578 | 553/533/**0** |

and adding a file with 500MB of random data into the device rootfs, it fails creating the system image with `cp: write error: No space left on device`

with the 15% addition:

| img file size | boot partition size | root partition size | root filesystem (size/used/avail) |
|-|-|-|-|
| 325 | 19 | 305 | 288/249/**20** |
| 407 | 19 | 387 | 367/306/**38** |
| 630 | 19 | 610 | 585/533/**8.9** |
| 900 | 19 | 880 | 851/769/**22** |

It's not the best solution since it depends a lot on the files that gets written but at least it doesn't fail with `no space left`.

Do you have other ideas/suggestion on how to better compute the minimal size and still have some free space inside?
