### PR TITLE
Fix weston on sony-amami

### DIFF
--- a/aports/device/device-sony-amami/90-android.rules
+++ b/aports/device/device-sony-amami/90-android.rules
@@ -2,7 +2,7 @@
 # All device names can be read from weston's logfile (/tmp/weston.log in postmarketOS)
 
 # Touchscreen (use 'weston-calibrator' to calibrate)
-SUBSYSTEM=="input", ATTRS{name}=="sec_touchscreen", \
+SUBSYSTEM=="input", ATTRS{name}=="clearpad", \
 ENV{ID_INPUT}="1", ENV{ID_INPUT_TOUCHSCREEN}="1" \
-ENV{WL_CALIBRATION}="0.982113 -0.006129 1.983124 -0.002560 1.000800 -6.012451"
+ENV{WL_CALIBRATION}="1.013786 0.035310 -24.920929 -0.008370 0.990421 12.094299"
 

--- a/aports/device/device-sony-amami/APKBUILD
+++ b/aports/device/device-sony-amami/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=device-sony-amami
 pkgver=1
-pkgrel=6
+pkgrel=7
 pkgdesc="Sony Xperia Z1 Compact"
 url="https://github.com/postmarketOS"
 arch="noarch"
@@ -9,7 +9,7 @@ depends="linux-sony-amami"
 makedepends=""
 install=""
 subpackages=""
-source="deviceinfo 90-android.rules"
+source="deviceinfo 90-android.rules fb-workaround.sh"
 options="!check"
 
 build() {
@@ -21,7 +21,10 @@ package() {
 		"$pkgdir/etc/deviceinfo"
 	install -D -m644 "$srcdir"/90-android.rules \
 		"$pkgdir"/etc/udev/rules.d/90-android.rules
+	install -D -m644 "$srcdir"/fb-workaround.sh \
+		"$pkgdir"/etc/profile.d/fb-workaround.sh
 }
 
 sha512sums="69884f1eeaf2372cfcd81930581af0dbe2b4a9afab49de681150a68599b07b0ffeb088e0c1c85b55da93e7d465d153b31c2916bda03bd75fbea445d2d885bbe2  deviceinfo
-d1c9feee9ca5f667a7f4e99654b9535ec41bde4684c3c7c5eeef530c95958af8b198d4f7c0adbf1a58e8072ad95beeb6c644d2aed5047c5b0c3f5fc7287bfe7b  90-android.rules"
+1dd1196aa9abe0308a0841147e7e5c6eb50da742cfc3194b90ef22a62d034b43ddade70384b78ab38fa0177da5a822f2a40f1386f4ecd591e2ecc80cb679133a  90-android.rules
+13f36f33cfae5e759b3889bc4e308324fd9bcf1cc7b097bbbe3646f1243b3bc06e1b1594cc8578c52c304a2b5006babd978c5b3f258769892e80552457889f99  fb-workaround.sh"

--- a/aports/device/device-sony-amami/fb-workaround.sh
+++ b/aports/device/device-sony-amami/fb-workaround.sh
@@ -1,0 +1,15 @@
+main() {
+	# Wait untill graphical enviroment is running
+	sleep 135
+	# Workaround for buggy graphics driver
+	for i in 1 2
+	do
+		echo "0,0" > /sys/class/graphics/fb0/pan
+	done
+}
+
+# tty1 autologin
+if [ $(tty) = "/dev/tty1" ]; then
+	# Run in background, to make /etc/profile not wait for it to finish
+	main &
+fi


### PR DESCRIPTION
See: https://github.com/postmarketOS/pmbootstrap/wiki/sony-amami-%28Xperia-Z1-Compact%29#framebuffer

The profile script needs to wait for `udevadm settle` to finish, hence the `sleep 135`.