### PR TITLE
Make gcc-aarch64 reproducible

### DIFF
--- a/aports/cross/gcc-aarch64/APKBUILD
+++ b/aports/cross/gcc-aarch64/APKBUILD
@@ -12,16 +12,39 @@ LANG_FORTRAN=false
 LANG_ADA=false
 options="!strip !tracedeps"
 
-# Replace hardlinks with symlinks, otherwise the links inside the tar will not
-# be reproducible!
+# Wrap the package function, to make the resulting package
+# lazy-reproducible
 package() {
-_package
+    # Repack the *.a files to be reproducible (see #64)
+    _temp="$_builddir"/_reproducible-patch
+    cd "$_builddir"
+    for f in $(find -name '*.a'); do
+        # Copy to a temporary folder
+        echo "Repack $f to be reproducible"
+        mkdir -p "$_temp"
+        cd "$_temp"
+        cp "$_builddir"/"$f" .
 
-echo "Replacing hardlinks with symlinks"
-rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
-ln -s -v /usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
-rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
-ln -s -v /usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
+        # Repack with a sorted file order
+        ar x *.a
+        rm *.a
+        ar r sorted.a $(find -name '*.o' | sort)
+
+        # Copy back and clean up
+        cp -v sorted.a "$_builddir"/"$f"
+        cd ..
+        rm -r "$_temp"
+    done
+
+    # Unmodified package function from the gcc APKBUILD
+    _package
+
+    # Workaround for: postmarketOS/binary-package-repo#1
+    echo "Replacing hardlinks with symlinks"
+    rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
+    ln -s -v /usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
+    rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
+    ln -s -v /usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
 }
 
 pkgname="gcc-aarch64"
@@ -333,26 +356,6 @@ build() {
 }
 
 _package() {
-            # Repack the *.a files to be reproducible (see #64)
-            _temp="$_builddir"/_reproducible-patch
-            cd "$_builddir"
-            for f in $(find -name '*.a'); do
-                # Copy to a temporary folder
-                echo "Repack $f to be reproducible"
-                mkdir -p "$_temp"
-                cd "$_temp"
-                cp "$_builddir"/"$f" .
-
-                # Repack with a sorted file order
-                ar x *.a
-                rm *.a
-                ar r sorted.a $(find -name '*.o' | sort)
-
-                # Copy back and clean up
-                cp -v sorted.a "$_builddir"/"$f"
-                cd ..
-                rm -r "$_temp"
-            done
 	cd "$_builddir"
 	make -j1 DESTDIR="${pkgdir}" install
 

--- a/aports/cross/gcc-aarch64/APKBUILD
+++ b/aports/cross/gcc-aarch64/APKBUILD
@@ -341,10 +341,6 @@ package() {
                 cd ..
                 rm -r "$_temp"
             done
-
-            # tar does not create reproducible archives with hardlinks, so use
-            # symlinks instead.
-            export LN='ln -s'
 	cd "$_builddir"
 	make -j1 DESTDIR="${pkgdir}" install
 

--- a/aports/cross/gcc-aarch64/APKBUILD
+++ b/aports/cross/gcc-aarch64/APKBUILD
@@ -341,6 +341,10 @@ package() {
                 cd ..
                 rm -r "$_temp"
             done
+
+            # tar does not create reproducible archives with hardlinks, so use
+            # symlinks instead.
+            export LN='ln -s'
 	cd "$_builddir"
 	make -j1 DESTDIR="${pkgdir}" install
 

--- a/aports/cross/gcc-aarch64/APKBUILD
+++ b/aports/cross/gcc-aarch64/APKBUILD
@@ -27,7 +27,7 @@ license="GPL LGPL"
 _gccrel=$pkgver-r$pkgrel
 depends="isl binutils-aarch64"
 makedepends_build="gcc g++ paxmark bison flex texinfo gawk zip gmp-dev mpfr-dev mpc1-dev zlib-dev"
-makedepends_host="linux-headers gmp-dev mpfr-dev mpc1-dev isl-dev zlib-dev musl-dev-aarch64 binutils-aarch64"
+makedepends_host="linux-headers gmp-dev mpfr-dev mpc1-dev isl-dev zlib-dev musl-dev-aarch64 binutils-aarch64 tar"
 subpackages="g++-aarch64:gpp"
 [ "$CHOST" = "$CTARGET" ] && subpackages="gcc-doc$_target"
 replaces="libstdc++ binutils"

--- a/aports/cross/gcc-aarch64/APKBUILD
+++ b/aports/cross/gcc-aarch64/APKBUILD
@@ -12,6 +12,15 @@ LANG_FORTRAN=false
 LANG_ADA=false
 options="!strip !tracedeps"
 
+# Replace the hardlink of g++ and c++ to the same file with a symbolic link
+# to make it reproducible (otherwise tar will randomly link one file or the
+# other in the archive!)
+package() {
+_package
+rm "$pkgdir"/usr/bin/"$CTARGET"-c++
+ln -s "$pkgdir"/usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
+}
+
 pkgname="gcc-aarch64"
 pkgver=6.4.0
 [ "$BOOTSTRAP" = "nolibc" ] && pkgname="gcc-pass2"
@@ -320,7 +329,7 @@ build() {
 	make
 }
 
-package() {
+_package() {
             # Repack the *.a files to be reproducible (see #64)
             _temp="$_builddir"/_reproducible-patch
             cd "$_builddir"

--- a/aports/cross/gcc-aarch64/APKBUILD
+++ b/aports/cross/gcc-aarch64/APKBUILD
@@ -12,13 +12,16 @@ LANG_FORTRAN=false
 LANG_ADA=false
 options="!strip !tracedeps"
 
-# Replace the hardlink of g++ and c++ to the same file with a symbolic link
-# to make it reproducible (otherwise tar will randomly link one file or the
-# other in the archive!)
+# Replace hardlinks with symlinks, otherwise the links inside the tar will not
+# be reproducible!
 package() {
 _package
-rm "$pkgdir"/usr/bin/"$CTARGET"-c++
-ln -s "$pkgdir"/usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
+
+echo "Replacing hardlinks with symlinks"
+rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
+ln -s -v "$pkgdir"/usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
+rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
+ln -s -v "$pkgdir"/usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
 }
 
 pkgname="gcc-aarch64"

--- a/aports/cross/gcc-aarch64/APKBUILD
+++ b/aports/cross/gcc-aarch64/APKBUILD
@@ -19,9 +19,9 @@ _package
 
 echo "Replacing hardlinks with symlinks"
 rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
-ln -s -v "$pkgdir"/usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
+ln -s -v /usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
 rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
-ln -s -v "$pkgdir"/usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
+ln -s -v /usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
 }
 
 pkgname="gcc-aarch64"

--- a/aports/cross/gcc-aarch64/APKBUILD
+++ b/aports/cross/gcc-aarch64/APKBUILD
@@ -27,7 +27,7 @@ license="GPL LGPL"
 _gccrel=$pkgver-r$pkgrel
 depends="isl binutils-aarch64"
 makedepends_build="gcc g++ paxmark bison flex texinfo gawk zip gmp-dev mpfr-dev mpc1-dev zlib-dev"
-makedepends_host="linux-headers gmp-dev mpfr-dev mpc1-dev isl-dev zlib-dev musl-dev-aarch64 binutils-aarch64 tar"
+makedepends_host="linux-headers gmp-dev mpfr-dev mpc1-dev isl-dev zlib-dev musl-dev-aarch64 binutils-aarch64"
 subpackages="g++-aarch64:gpp"
 [ "$CHOST" = "$CTARGET" ] && subpackages="gcc-doc$_target"
 replaces="libstdc++ binutils"

--- a/aports/cross/gcc-armhf/APKBUILD
+++ b/aports/cross/gcc-armhf/APKBUILD
@@ -27,7 +27,7 @@ license="GPL LGPL"
 _gccrel=$pkgver-r$pkgrel
 depends="isl binutils-armhf"
 makedepends_build="gcc g++ paxmark bison flex texinfo gawk zip gmp-dev mpfr-dev mpc1-dev zlib-dev"
-makedepends_host="linux-headers gmp-dev mpfr-dev mpc1-dev isl-dev zlib-dev musl-dev-armhf binutils-armhf"
+makedepends_host="linux-headers gmp-dev mpfr-dev mpc1-dev isl-dev zlib-dev musl-dev-armhf binutils-armhf tar"
 subpackages="g++-armhf:gpp"
 [ "$CHOST" = "$CTARGET" ] && subpackages="gcc-doc$_target"
 replaces="libstdc++ binutils"

--- a/aports/cross/gcc-armhf/APKBUILD
+++ b/aports/cross/gcc-armhf/APKBUILD
@@ -341,10 +341,6 @@ package() {
                 cd ..
                 rm -r "$_temp"
             done
-
-            # tar does not create reproducible archives with hardlinks, so use
-            # symlinks instead.
-            export LN='ln -s'
 	cd "$_builddir"
 	make -j1 DESTDIR="${pkgdir}" install
 

--- a/aports/cross/gcc-armhf/APKBUILD
+++ b/aports/cross/gcc-armhf/APKBUILD
@@ -12,16 +12,39 @@ LANG_FORTRAN=false
 LANG_ADA=false
 options="!strip !tracedeps"
 
-# Replace hardlinks with symlinks, otherwise the links inside the tar will not
-# be reproducible!
+# Wrap the package function, to make the resulting package
+# lazy-reproducible
 package() {
-_package
+    # Repack the *.a files to be reproducible (see #64)
+    _temp="$_builddir"/_reproducible-patch
+    cd "$_builddir"
+    for f in $(find -name '*.a'); do
+        # Copy to a temporary folder
+        echo "Repack $f to be reproducible"
+        mkdir -p "$_temp"
+        cd "$_temp"
+        cp "$_builddir"/"$f" .
 
-echo "Replacing hardlinks with symlinks"
-rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
-ln -s -v /usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
-rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
-ln -s -v /usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
+        # Repack with a sorted file order
+        ar x *.a
+        rm *.a
+        ar r sorted.a $(find -name '*.o' | sort)
+
+        # Copy back and clean up
+        cp -v sorted.a "$_builddir"/"$f"
+        cd ..
+        rm -r "$_temp"
+    done
+
+    # Unmodified package function from the gcc APKBUILD
+    _package
+
+    # Workaround for: postmarketOS/binary-package-repo#1
+    echo "Replacing hardlinks with symlinks"
+    rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
+    ln -s -v /usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
+    rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
+    ln -s -v /usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
 }
 
 pkgname="gcc-armhf"
@@ -333,26 +356,6 @@ build() {
 }
 
 _package() {
-            # Repack the *.a files to be reproducible (see #64)
-            _temp="$_builddir"/_reproducible-patch
-            cd "$_builddir"
-            for f in $(find -name '*.a'); do
-                # Copy to a temporary folder
-                echo "Repack $f to be reproducible"
-                mkdir -p "$_temp"
-                cd "$_temp"
-                cp "$_builddir"/"$f" .
-
-                # Repack with a sorted file order
-                ar x *.a
-                rm *.a
-                ar r sorted.a $(find -name '*.o' | sort)
-
-                # Copy back and clean up
-                cp -v sorted.a "$_builddir"/"$f"
-                cd ..
-                rm -r "$_temp"
-            done
 	cd "$_builddir"
 	make -j1 DESTDIR="${pkgdir}" install
 

--- a/aports/cross/gcc-armhf/APKBUILD
+++ b/aports/cross/gcc-armhf/APKBUILD
@@ -341,6 +341,10 @@ package() {
                 cd ..
                 rm -r "$_temp"
             done
+
+            # tar does not create reproducible archives with hardlinks, so use
+            # symlinks instead.
+            export LN='ln -s'
 	cd "$_builddir"
 	make -j1 DESTDIR="${pkgdir}" install
 

--- a/aports/cross/gcc-armhf/APKBUILD
+++ b/aports/cross/gcc-armhf/APKBUILD
@@ -12,13 +12,16 @@ LANG_FORTRAN=false
 LANG_ADA=false
 options="!strip !tracedeps"
 
-# Replace the hardlink of g++ and c++ to the same file with a symbolic link
-# to make it reproducible (otherwise tar will randomly link one file or the
-# other in the archive!)
+# Replace hardlinks with symlinks, otherwise the links inside the tar will not
+# be reproducible!
 package() {
 _package
-rm "$pkgdir"/usr/bin/"$CTARGET"-c++
-ln -s "$pkgdir"/usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
+
+echo "Replacing hardlinks with symlinks"
+rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
+ln -s -v "$pkgdir"/usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
+rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
+ln -s -v "$pkgdir"/usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
 }
 
 pkgname="gcc-armhf"

--- a/aports/cross/gcc-armhf/APKBUILD
+++ b/aports/cross/gcc-armhf/APKBUILD
@@ -12,6 +12,15 @@ LANG_FORTRAN=false
 LANG_ADA=false
 options="!strip !tracedeps"
 
+# Replace the hardlink of g++ and c++ to the same file with a symbolic link
+# to make it reproducible (otherwise tar will randomly link one file or the
+# other in the archive!)
+package() {
+_package
+rm "$pkgdir"/usr/bin/"$CTARGET"-c++
+ln -s "$pkgdir"/usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
+}
+
 pkgname="gcc-armhf"
 pkgver=6.4.0
 [ "$BOOTSTRAP" = "nolibc" ] && pkgname="gcc-pass2"
@@ -320,7 +329,7 @@ build() {
 	make
 }
 
-package() {
+_package() {
             # Repack the *.a files to be reproducible (see #64)
             _temp="$_builddir"/_reproducible-patch
             cd "$_builddir"

--- a/aports/cross/gcc-armhf/APKBUILD
+++ b/aports/cross/gcc-armhf/APKBUILD
@@ -19,9 +19,9 @@ _package
 
 echo "Replacing hardlinks with symlinks"
 rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
-ln -s -v "$pkgdir"/usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
+ln -s -v /usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
 rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
-ln -s -v "$pkgdir"/usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
+ln -s -v /usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
 }
 
 pkgname="gcc-armhf"

--- a/aports/cross/gcc-armhf/APKBUILD
+++ b/aports/cross/gcc-armhf/APKBUILD
@@ -27,7 +27,7 @@ license="GPL LGPL"
 _gccrel=$pkgver-r$pkgrel
 depends="isl binutils-armhf"
 makedepends_build="gcc g++ paxmark bison flex texinfo gawk zip gmp-dev mpfr-dev mpc1-dev zlib-dev"
-makedepends_host="linux-headers gmp-dev mpfr-dev mpc1-dev isl-dev zlib-dev musl-dev-armhf binutils-armhf tar"
+makedepends_host="linux-headers gmp-dev mpfr-dev mpc1-dev isl-dev zlib-dev musl-dev-armhf binutils-armhf"
 subpackages="g++-armhf:gpp"
 [ "$CHOST" = "$CTARGET" ] && subpackages="gcc-doc$_target"
 replaces="libstdc++ binutils"

--- a/pmb/aportgen/core.py
+++ b/pmb/aportgen/core.py
@@ -62,7 +62,9 @@ def rewrite(args, pkgname, path_original, fields={}, replace_pkgname=None,
         "\n",
     ]
     for line in below_header.split("\n"):
-        lines_new += line.strip() + "\n"
+        if not line[:8].strip():
+            line = line[8:]
+        lines_new += line.rstrip() + "\n"
 
     # Copy/modify lines, skip Maintainer/Contributor
     path = args.work + "/aportgen/APKBUILD"

--- a/pmb/aportgen/gcc.py
+++ b/pmb/aportgen/gcc.py
@@ -52,30 +52,9 @@ def generate(args, pkgname):
         LANG_ADA=false
         options="!strip !tracedeps"
 
-        # Replace hardlinks with symlinks, otherwise the links inside the tar will not
-        # be reproducible!
+        # Wrap the package function, to make the resulting package
+        # lazy-reproducible
         package() {
-            _package
-
-            echo "Replacing hardlinks with symlinks"
-            rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
-            ln -s -v /usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
-            rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
-            ln -s -v /usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
-        }
-    """
-
-    replace_simple = {
-        # Do not package libstdc++, do not add "g++-$ARCH" here (already
-        # did that explicitly in the subpackages variable above, so
-        # pmbootstrap picks it up properly).
-        '*subpackages="$subpackages libstdc++:libcxx:*': None,
-
-        # libstdc++.a is not reproducible by default (.a files are archives of
-        # object files, and these object files are inside the .a file in a random
-        # order!). The best way would be to patch this upstream in gcc, but for now
-        # we repackage the .a files to make sure, that they are reproducible.
-        '*package() {*': """_package() {
             # Repack the *.a files to be reproducible (see #64)
             _temp="$_builddir"/_reproducible-patch
             cd "$_builddir"
@@ -95,7 +74,28 @@ def generate(args, pkgname):
                 cp -v sorted.a "$_builddir"/"$f"
                 cd ..
                 rm -r "$_temp"
-            done"""
+            done
+
+            # Unmodified package function from the gcc APKBUILD
+            _package
+
+            # Workaround for: postmarketOS/binary-package-repo#1
+            echo "Replacing hardlinks with symlinks"
+            rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
+            ln -s -v /usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
+            rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
+            ln -s -v /usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
+        }
+    """
+
+    replace_simple = {
+        # Do not package libstdc++, do not add "g++-$ARCH" here (already
+        # did that explicitly in the subpackages variable above, so
+        # pmbootstrap picks it up properly).
+        '*subpackages="$subpackages libstdc++:libcxx:*': None,
+
+        # Rename package to _package, so we can wrap it (see above)
+        '*package() {*': "_package() {"
     }
 
     pmb.aportgen.core.rewrite(

--- a/pmb/aportgen/gcc.py
+++ b/pmb/aportgen/gcc.py
@@ -33,11 +33,7 @@ def generate(args, pkgname):
         "pkgdesc": "Stage2 cross-compiler for " + arch,
         "depends": "isl binutils-" + arch,
         "makedepends_build": "gcc g++ paxmark bison flex texinfo gawk zip gmp-dev mpfr-dev mpc1-dev zlib-dev",
-        "makedepends_host": "linux-headers gmp-dev mpfr-dev mpc1-dev"
-                            " isl-dev zlib-dev musl-dev-" + arch +
-                            " binutils-" + arch +
-                            # busybox' tar does not create reproducible archives with hardlinks
-                            " tar",
+        "makedepends_host": "linux-headers gmp-dev mpfr-dev mpc1-dev isl-dev zlib-dev musl-dev-" + arch + " binutils-" + arch,
         "subpackages": "g++-" + arch + ":gpp",
 
         "LIBGOMP": "false",

--- a/pmb/aportgen/gcc.py
+++ b/pmb/aportgen/gcc.py
@@ -59,9 +59,9 @@ def generate(args, pkgname):
 
             echo "Replacing hardlinks with symlinks"
             rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
-            ln -s -v "$pkgdir"/usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
+            ln -s -v /usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
             rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
-            ln -s -v "$pkgdir"/usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
+            ln -s -v /usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
         }
     """
 

--- a/pmb/aportgen/gcc.py
+++ b/pmb/aportgen/gcc.py
@@ -51,6 +51,15 @@ def generate(args, pkgname):
         LANG_FORTRAN=false
         LANG_ADA=false
         options="!strip !tracedeps"
+
+        # Replace the hardlink of g++ and c++ to the same file with a symbolic link
+        # to make it reproducible (otherwise tar will randomly link one file or the
+        # other in the archive!)
+        package() {
+            _package
+            rm "$pkgdir"/usr/bin/"$CTARGET"-c++
+            ln -s "$pkgdir"/usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
+        }
     """
 
     replace_simple = {
@@ -63,7 +72,7 @@ def generate(args, pkgname):
         # object files, and these object files are inside the .a file in a random
         # order!). The best way would be to patch this upstream in gcc, but for now
         # we repackage the .a files to make sure, that they are reproducible.
-        '*package() {*': """package() {
+        '*package() {*': """_package() {
             # Repack the *.a files to be reproducible (see #64)
             _temp="$_builddir"/_reproducible-patch
             cd "$_builddir"

--- a/pmb/aportgen/gcc.py
+++ b/pmb/aportgen/gcc.py
@@ -83,11 +83,7 @@ def generate(args, pkgname):
                 cp -v sorted.a "$_builddir"/"$f"
                 cd ..
                 rm -r "$_temp"
-            done
-
-            # tar does not create reproducible archives with hardlinks, so use
-            # symlinks instead.
-            export LN='ln -s'"""
+            done"""
     }
 
     pmb.aportgen.core.rewrite(

--- a/pmb/aportgen/gcc.py
+++ b/pmb/aportgen/gcc.py
@@ -83,7 +83,11 @@ def generate(args, pkgname):
                 cp -v sorted.a "$_builddir"/"$f"
                 cd ..
                 rm -r "$_temp"
-            done"""
+            done
+
+            # tar does not create reproducible archives with hardlinks, so use
+            # symlinks instead.
+            export LN='ln -s'"""
     }
 
     pmb.aportgen.core.rewrite(

--- a/pmb/aportgen/gcc.py
+++ b/pmb/aportgen/gcc.py
@@ -52,13 +52,16 @@ def generate(args, pkgname):
         LANG_ADA=false
         options="!strip !tracedeps"
 
-        # Replace the hardlink of g++ and c++ to the same file with a symbolic link
-        # to make it reproducible (otherwise tar will randomly link one file or the
-        # other in the archive!)
+        # Replace hardlinks with symlinks, otherwise the links inside the tar will not
+        # be reproducible!
         package() {
             _package
-            rm "$pkgdir"/usr/bin/"$CTARGET"-c++
-            ln -s "$pkgdir"/usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
+
+            echo "Replacing hardlinks with symlinks"
+            rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
+            ln -s -v "$pkgdir"/usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
+            rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
+            ln -s -v "$pkgdir"/usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
         }
     """
 

--- a/pmb/aportgen/gcc.py
+++ b/pmb/aportgen/gcc.py
@@ -33,7 +33,11 @@ def generate(args, pkgname):
         "pkgdesc": "Stage2 cross-compiler for " + arch,
         "depends": "isl binutils-" + arch,
         "makedepends_build": "gcc g++ paxmark bison flex texinfo gawk zip gmp-dev mpfr-dev mpc1-dev zlib-dev",
-        "makedepends_host": "linux-headers gmp-dev mpfr-dev mpc1-dev isl-dev zlib-dev musl-dev-" + arch + " binutils-" + arch,
+        "makedepends_host": "linux-headers gmp-dev mpfr-dev mpc1-dev"
+                            " isl-dev zlib-dev musl-dev-" + arch +
+                            " binutils-" + arch +
+                            # busybox' tar does not create reproducible archives with hardlinks
+                            " tar",
         "subpackages": "g++-" + arch + ":gpp",
 
         "LIBGOMP": "false",

--- a/pmb/build/init.py
+++ b/pmb/build/init.py
@@ -35,8 +35,12 @@ def wrap_tar(args, suffix):
         with open(chroot + "/tmp/tar_wrapper.sh", "w") as handle:
             content = """
                 #!/bin/sh
-                # Reproducible file order, important for hardlinks
-                /bin/tar --sort=name "$@"
+                if [ "$1" == "-f" ] && [ "$2" == "-" ] && [ "$3" == "-c" ]; then
+                    # Getting called from apk, sort archive content
+                    /bin/tar --sort=name "$@"
+                else
+                    /bin/tar "$@"
+                fi
             """
             lines = content.split("\n")[1:]
             for i in range(len(lines)):

--- a/pmb/build/init.py
+++ b/pmb/build/init.py
@@ -35,12 +35,8 @@ def wrap_tar(args, suffix):
         with open(chroot + "/tmp/tar_wrapper.sh", "w") as handle:
             content = """
                 #!/bin/sh
-                if [ "$1" == "-f" ] && [ "$2" == "-" ] && [ "$3" == "-c" ]; then
-                    # Getting called from apk, sort archive content
-                    /bin/tar --sort=name "$@"
-                else
-                    /bin/tar "$@"
-                fi
+                # Reproducible file order, important for hardlinks
+                /bin/tar --sort=name "$@"
             """
             lines = content.split("\n")[1:]
             for i in range(len(lines)):

--- a/pmb/build/init.py
+++ b/pmb/build/init.py
@@ -26,52 +26,6 @@ import pmb.chroot.apk
 import pmb.helpers.run
 
 
-def wrap_tar(args, suffix):
-    """
-    Add tar wrapper, that adds options to make the archives deterministic
-    """
-    chroot = args.work + "/chroot_" + suffix
-    if not os.path.exists(chroot + "/usr/local/bin/tar"):
-        with open(chroot + "/tmp/tar_wrapper.sh", "w") as handle:
-            content = """
-                #!/bin/sh
-                # Reproducible file order, important for hardlinks
-                /bin/tar --sort=name "$@"
-            """
-            lines = content.split("\n")[1:]
-            for i in range(len(lines)):
-                lines[i] = lines[i][16:]
-            handle.write("\n".join(lines))
-        pmb.chroot.root(args, ["cp", "/tmp/tar_wrapper.sh", "/usr/local/bin/tar"],
-                        suffix)
-        pmb.chroot.root(args, ["chmod", "+x", "/usr/local/bin/tar"], suffix)
-
-
-def wrap_gzip(args, suffix):
-    # Add gzip wrapper, that converts '-9' to '-1'
-    chroot = args.work + "/chroot_" + suffix
-    if not os.path.exists(chroot + "/usr/local/bin/gzip"):
-        with open(chroot + "/tmp/gzip_wrapper.sh", "w") as handle:
-            content = """
-                #!/bin/sh
-                # Simple wrapper, that converts -9 flag for gzip to -1 for speed
-                # improvement with abuild. FIXME: upstream to abuild with a flag!
-                args=""
-                for arg in "$@"; do
-                    [ "$arg" == "-9" ] && arg="-1"
-                    args="$args $arg"
-                done
-                /bin/gzip $args
-            """
-            lines = content.split("\n")[1:]
-            for i in range(len(lines)):
-                lines[i] = lines[i][16:]
-            handle.write("\n".join(lines))
-        pmb.chroot.root(args, ["cp", "/tmp/gzip_wrapper.sh", "/usr/local/bin/gzip"],
-                        suffix)
-        pmb.chroot.root(args, ["chmod", "+x", "/usr/local/bin/gzip"], suffix)
-
-
 def init(args, suffix="native"):
     # Check if already initialized
     marker = "/var/local/pmbootstrap_chroot_build_init_done"
@@ -98,6 +52,28 @@ def init(args, suffix="native"):
             key = key[len(chroot):]
             pmb.chroot.root(args, ["cp", key, "/etc/apk/keys/"], suffix)
 
+    # Add gzip wrapper, that converts '-9' to '-1'
+    if not os.path.exists(chroot + "/usr/local/bin/gzip"):
+        with open(chroot + "/tmp/gzip_wrapper.sh", "w") as handle:
+            content = """
+                #!/bin/sh
+                # Simple wrapper, that converts -9 flag for gzip to -1 for speed
+                # improvement with abuild. FIXME: upstream to abuild with a flag!
+                args=""
+                for arg in "$@"; do
+                    [ "$arg" == "-9" ] && arg="-1"
+                    args="$args $arg"
+                done
+                /bin/gzip $args
+            """
+            lines = content.split("\n")[1:]
+            for i in range(len(lines)):
+                lines[i] = lines[i][16:]
+            handle.write("\n".join(lines))
+        pmb.chroot.root(args, ["cp", "/tmp/gzip_wrapper.sh", "/usr/local/bin/gzip"],
+                        suffix)
+        pmb.chroot.root(args, ["chmod", "+x", "/usr/local/bin/gzip"], suffix)
+
     # Add user to group abuild
     pmb.chroot.root(args, ["adduser", "user", "abuild"], suffix)
 
@@ -105,10 +81,6 @@ def init(args, suffix="native"):
     # inspect it afterwards for debugging
     pmb.chroot.root(args, ["sed", "-i", "-e", "s/^CLEANUP=.*/CLEANUP=''/",
                            "/etc/abuild.conf"], suffix)
-
-    # Wrap tar and gzip
-    wrap_tar(args, suffix)
-    wrap_gzip(args, suffix)
 
     # Mark the chroot as initialized
     pmb.chroot.root(args, ["touch", marker], suffix)

--- a/pmb/challenge/apk_file.py
+++ b/pmb/challenge/apk_file.py
@@ -100,8 +100,10 @@ def apk(args, apk_a, apk_b, stop_after_first_error=False):
                     member_a = tar_a.getmember(name)
                     member_b = tar_b.getmember(name)
                     if member_a.type != member_b.type:
-                        logging.info("NOTE: Type in " + apk_a + ": " + str(member_a.type))
-                        logging.info("NOTE: Type in " + apk_b + ": " + str(member_b.type))
+                        logging.info("NOTE: " + name + " in " + apk_a + ":")
+                        tar_a.list(members=[member_a])
+                        logging.info("NOTE: " + name + " in " + apk_b + ":")
+                        tar_b.list(members=[member_b])
                         raise RuntimeError(
                             "Entry '" + name + "' has a different type!")
 

--- a/pmb/challenge/apk_file.py
+++ b/pmb/challenge/apk_file.py
@@ -100,6 +100,8 @@ def apk(args, apk_a, apk_b, stop_after_first_error=False):
                     member_a = tar_a.getmember(name)
                     member_b = tar_b.getmember(name)
                     if member_a.type != member_b.type:
+                        logging.info("NOTE: Type in " + apk_a + ": " + str(member_a.type))
+                        logging.info("NOTE: Type in " + apk_b + ": " + str(member_b.type))
                         raise RuntimeError(
                             "Entry '" + name + "' has a different type!")
 


### PR DESCRIPTION
This will fix https://github.com/postmarketOS/binary-package-repo/issues/1.

GCC generates hardlinks between files `A` and `B` in its `make install` step. The problem is, that `tar` randomly packages `A` as full binary, and links `B` to `A`, or the other way around! I was able to reproduce this issue consistently when re-building `gcc-aarch64` on Travis CI (interestingly, this did not appear for `gcc-armhf`).

The fix is, to delete `B` and create a symlink `B` that points to `A` instead.

### How to test this PR
```shell
pmbootstrap zap -p
pmbootstrap build hello-world --arch=armhf
pmbootstrap build hello-world --arch=aarch64
```