### PR TITLE
(binary repo reated) Don't specify pkgnames from "provides" as dependencies

### DIFF
--- a/pmb/build/other.py
+++ b/pmb/build/other.py
@@ -257,8 +257,8 @@ def index_repo(args, arch=None):
         ]
         for command in commands:
             pmb.chroot.user(args, command, working_dir=path_repo_chroot)
-        pmb.parse.apkindex.clear_cache(args, args.work + path
-                                       + "/APKINDEX.tar.gz")
+        pmb.parse.apkindex.clear_cache(args, args.work + path +
+                                       "/APKINDEX.tar.gz")
 
 
 def symlink_noarch_package(args, arch_apk):

--- a/pmb/build/other.py
+++ b/pmb/build/other.py
@@ -232,6 +232,10 @@ def is_necessary(args, arch, apkbuild, apkindex_path=None):
 
 def index_repo(args, arch=None):
     """
+    Recreate the APKINDEX.tar.gz for a specific repo, and clear the parsing
+    cache for that file for the current pmbootstrap session (to prevent
+    rebuilding packages twice, in case the rebuild takes less than a second).
+
     :param arch: when not defined, re-index all repos
     """
     pmb.build.init(args)
@@ -253,6 +257,8 @@ def index_repo(args, arch=None):
         ]
         for command in commands:
             pmb.chroot.user(args, command, working_dir=path_repo_chroot)
+        pmb.parse.apkindex.clear_cache(args, args.work + path
+                                       + "/APKINDEX.tar.gz")
 
 
 def symlink_noarch_package(args, arch_apk):

--- a/pmb/build/package.py
+++ b/pmb/build/package.py
@@ -69,6 +69,10 @@ def package(args, pkgname, carch, force=False, buildinfo=False):
                                    build=False)
             pmb.chroot.distccd.start(args, carch_buildenv)
 
+    # Avoid re-building for circular dependencies
+    if not force and not pmb.build.is_necessary(args, carch, apkbuild):
+        return
+
     # Configure abuild.conf
     pmb.build.other.configure_abuild(args, suffix)
 
@@ -115,5 +119,9 @@ def package(args, pkgname, carch, force=False, buildinfo=False):
     # Symlink noarch packages
     if "noarch" in apkbuild["arch"]:
         pmb.build.symlink_noarch_package(args, output)
+
+    # Clear APKINDEX cache
+    pmb.parse.apkindex.clear_cache(args, args.work + "/packages/" +
+                                   carch_buildenv + "/APKINDEX.tar.gz")
 
     return output

--- a/pmb/parse/apkindex.py
+++ b/pmb/parse/apkindex.py
@@ -198,6 +198,15 @@ def parse(args, path, strict=False):
     return ret
 
 
+def clear_cache(args, path):
+    logging.verbose("Clear APKINDEX cache for: " + path)
+    if path in args.cache["apkindex"]:
+        del args.cache["apkindex"][path]
+    else:
+        logging.verbose("Nothing to do, path was not in cache:" +
+                        str(args.cache["apkindex"].keys()))
+
+
 def read(args, package, path, must_exist=True):
     """
     Get information about a single package from an APKINDEX.tar.gz file.


### PR DESCRIPTION
One good review and testing would really be appreaciated (and bring us one step closer to the binary repo)!

### Context
In a nutshell, I'm working on a binary repository, for which all packages get reproduced by Travis CI (and verified if the binaries in the package are identical!) before they get published.
To do that, the packages in the "staging repo" get built with a `buildinfo.json` file, which lists all installed versions of all dependencies. Currently that file also contains some `so:` entries automatically added by Alpine as dependency (which causes the breakage for re-building weston, becase `pmbootstrap` will not know that `weston` provides `so:libweston` when it gets built from the `aports` folder).

### The changes

Always use the regular pkgname. That way, we avoid listing all
kinds of so: files as dependencies (because Alpine automatically
adds them as depends= to the package database). This fixes building
weston, and reproducing the build with `pmbootstrap challenge`.

Additional changes.
* Clear the parsed APKINDEX cache for the current pmbootstrap
  session after building a package
* Avoid rebuilding a package, in case it was already built due to
  circular dependenices

This will fix:
https://github.com/postmarketOS/binary-package-repo/issues/7

I've tested it, and [built `weston` successfully](https://github.com/postmarketOS/binary-package-repo/commit/526d92e424134bab574d9274114966442347aae1) for the up-coming binary repo.

### How to test
If you have the CPU power, to simply test if this introduced any breakage with building packages, use:
```shell
pmbootstrap zap -p # WARNING: will delete your precious binary packages! backup if necessary
pmbootstrap install
```
... and see if it runs through.