### PR TITLE
Add initial setup.py (#327)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/pmb/__init__.py
+++ b/pmb/__init__.py
@@ -16,3 +16,54 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with pmbootstrap.  If not, see <http://www.gnu.org/licenses/>.
 """
+
+
+import sys
+import logging
+import os
+import traceback
+
+from . import config
+from . import parse
+from .helpers import frontend
+from .helpers import logging as pmb_logging
+from .helpers import other
+
+
+def main():
+    # Parse arguments, set up logging
+    args = parse.arguments()
+    pmb_logging.init(args)
+
+    # Wrap everything to display nice error messages
+    try:
+        # Sanity check
+        other.check_grsec(args)
+
+        # Initialize or require config
+        if args.action == "init":
+            return config.init(args)
+        elif not os.path.exists(args.config):
+            logging.critical("Please specify a config file, or run"
+                             " 'pmbootstrap init' to generate one.")
+            return 1
+
+        # Run the function with the action's name (in pmb/helpers/frontend.py)
+        if args.action:
+            getattr(frontend, args.action)(args)
+        else:
+            logging.info("Run pmbootstrap -h for usage information.")
+
+        # Print finish timestamp
+        logging.info("Done")
+
+    except Exception as e:
+        logging.info("ERROR: " + str(e))
+        logging.info("Run 'pmbootstrap log' for details.")
+        logging.info("See also: <https://postmarketos.org/troubleshooting>")
+        logging.debug(traceback.format_exc())
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pmb/parse/deviceinfo.py
+++ b/pmb/parse/deviceinfo.py
@@ -28,6 +28,11 @@ def deviceinfo(args, device=None):
     if not device:
         device = args.device
 
+    if not os.path.exists(args.aports):
+        logging.fatal("Aports directory is missing")
+        logging.fatal("Please provide a path to the aports directory using the -p flag")
+        raise RuntimeError("Aports directory missing")
+
     aport = args.aports + "/device/device-" + device
     if not os.path.exists(aport) or not os.path.exists(aport + "/deviceinfo"):
         logging.fatal("You will need to create a device-specific package")

--- a/pmbootstrap.py
+++ b/pmbootstrap.py
@@ -20,50 +20,7 @@ along with pmbootstrap.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import sys
-import logging
-import os
-import traceback
-import pmb.config
-import pmb.helpers.frontend
-import pmb.helpers.logging
-import pmb.helpers.other
-import pmb.parse
-
-
-def main():
-    # Parse arguments, set up logging
-    args = pmb.parse.arguments()
-    pmb.helpers.logging.init(args)
-
-    # Wrap everything to display nice error messages
-    try:
-        # Sanity check
-        pmb.helpers.other.check_grsec(args)
-
-        # Initialize or require config
-        if args.action == "init":
-            return pmb.config.init(args)
-        elif not os.path.exists(args.config):
-            logging.critical("Please specify a config file, or run"
-                             " 'pmbootstrap init' to generate one.")
-            return 1
-
-        # Run the function with the action's name (in pmb/helpers/frontend.py)
-        if args.action:
-            getattr(pmb.helpers.frontend, args.action)(args)
-        else:
-            logging.info("Run pmbootstrap -h for usage information.")
-
-        # Print finish timestamp
-        logging.info("Done")
-
-    except Exception as e:
-        logging.info("ERROR: " + str(e))
-        logging.info("Run 'pmbootstrap log' for details.")
-        logging.info("See also: <https://postmarketos.org/troubleshooting>")
-        logging.debug(traceback.format_exc())
-        return 1
-
+import pmb
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(pmb.main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand
+
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+
+class PyTest(TestCommand):
+    user_options = [('pytest-args=', 'a', 'Arguments to pass to pytest')]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = ''
+
+    def run_tests(self):
+        import shlex
+        import pytest
+        errno = pytest.main(shlex.split(self.pytest_args))
+        sys.exit(errno)
+
+setup(
+    name='pmbootstrap',
+    version='0.0.1',
+    description='A sopisticated chroot / build / flash tool to develop and install postmarketOS',
+    long_description=long_description,
+    author='postmarketOS Developers',
+    author_email='info@postmarketos.org',
+    url='https://www.postmarketos.org',
+    license='GPLv3',
+    python_requires='>=3.4',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved ::GNU General Public License v3 (GPLv3)',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
+    keywords='postmarketos pmbootstrap',
+    packages=find_packages(exclude=['aports', 'build', 'dist', 'keys', 'tests']),
+    tests_require=['pytest'],
+    cmdclass = {'test': PyTest},
+    entry_points={
+        'console_scripts': [
+            'pmbootstrap=pmb:main',
+        ],
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
-        'License :: OSI Approved ::GNU General Public License v3 (GPLv3)',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     keywords='postmarketos pmbootstrap',
     packages=find_packages(exclude=['aports', 'keys', 'test']),
     tests_require=['pytest'],
-    cmdclass = {'test': PyTest},
+    cmdclass={'test': PyTest},
     entry_points={
         'console_scripts': [
             'pmbootstrap=pmb:main',

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,6 @@ from setuptools.command.test import test as TestCommand
 from codecs import open
 from os import path
 
-here = path.abspath(path.dirname(__file__))
-
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
-
 
 class PyTest(TestCommand):
     user_options = [('pytest-args=', 'a', 'Arguments to pass to pytest')]
@@ -29,9 +24,15 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
+here = path.abspath(path.dirname(__file__))
 _version_re = re.compile(r'version\s+=\s+(.*)')
+
 with open(path.join(here, 'pmb/config/__init__.py'), 'rb') as f:
     version = str(ast.literal_eval(_version_re.search(f.read().decode('utf-8')).group(1)))
+
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
 
 setup(
     name='pmbootstrap',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     keywords='postmarketos pmbootstrap',
-    packages=find_packages(exclude=['aports', 'build', 'dist', 'keys', 'tests']),
+    packages=find_packages(exclude=['aports', 'keys', 'test']),
     tests_require=['pytest'],
     cmdclass = {'test': PyTest},
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 import re
 import ast
+import sys
 
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+import re
+import ast
+
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
@@ -25,10 +28,15 @@ class PyTest(TestCommand):
         errno = pytest.main(shlex.split(self.pytest_args))
         sys.exit(errno)
 
+
+_version_re = re.compile(r'version\s+=\s+(.*)')
+with open(path.join(here, 'pmb/config/__init__.py'), 'rb') as f:
+    version = str(ast.literal_eval(_version_re.search(f.read().decode('utf-8')).group(1)))
+
 setup(
     name='pmbootstrap',
-    version='0.0.1',
-    description='A sopisticated chroot / build / flash tool to develop and install postmarketOS',
+    version=version,
+    description='A sophisticated chroot / build / flash tool to develop and install postmarketOS',
     long_description=long_description,
     author='postmarketOS Developers',
     author_email='info@postmarketos.org',


### PR DESCRIPTION
Started to prepare an initial `setup.py` according to [Python packaging best practices](https://packaging.python.org/tutorials/distributing-packages/)

- Supports package installation with a `pmbootstrap` entry point executable
- Supports `pytest` testing
- Moved all entry point logic into `pmb` module, had to fix some imports
- Dynamically resolves version from `pmb/config/__init__.py` using regex (see https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version)

Running `pmbootstrap` after installing it system-wide (or into a virtualenv) currently **requires** the usage of the `-p aports` flag. But this discussion is probably more relevant in #383.