### PR TITLE
Flavor instead of device name when creating recovery zip

### DIFF
--- a/pmb/flasher/frontend.py
+++ b/pmb/flasher/frontend.py
@@ -25,34 +25,12 @@ import pmb.install
 import pmb.chroot.apk
 import pmb.chroot.initfs
 import pmb.chroot.other
-
-
-def parse_flavor_arg(args):
-    """
-    Verify the flavor argument if specified, or return a default value.
-    """
-    # Make sure, that at least one kernel is installed
-    suffix = "rootfs_" + args.device
-    pmb.chroot.apk.install(args, ["device-" + args.device], suffix)
-
-    # Parse and verify the flavor argument
-    flavor = args.flavor
-    flavors = pmb.chroot.other.kernel_flavors_installed(args, suffix)
-    if flavor:
-        if flavor not in flavors:
-            raise RuntimeError("No kernel installed with flavor " + flavor + "!" +
-                               " Run 'pmbootstrap flasher list_flavors' to get a list.")
-        return flavor
-    if not len(flavors):
-        raise RuntimeError(
-            "No kernel flavors installed in chroot " + suffix + "! Please let"
-            " your device package depend on a package starting with 'linux-'.")
-    return flavors[0]
+import pmb.helpers.frontend
 
 
 def kernel(args):
     # Rebuild the initramfs, just to make sure (see #69)
-    flavor = parse_flavor_arg(args)
+    flavor = pmb.helpers.frontend._parse_flavor(args)
     pmb.chroot.initfs.build(args, flavor, "rootfs_" + args.device)
 
     # Generate the paths and run the flasher
@@ -126,7 +104,7 @@ def export(args):
                      " install' first (without the 'sdcard' parameter).")
 
     # Rebuild the initramfs, just to make sure (see #69)
-    flavor = parse_flavor_arg(args)
+    flavor = pmb.helpers.frontend._parse_flavor(args)
     pmb.chroot.initfs.build(args, flavor, "rootfs_" + args.device)
 
     pmb.flasher.export(args, flavor, args.export_folder)

--- a/pmb/helpers/frontend.py
+++ b/pmb/helpers/frontend.py
@@ -39,6 +39,29 @@ import pmb.parse
 import pmb.qemu
 
 
+def _parse_flavor(args):
+    """
+    Verify the flavor argument if specified, or return a default value.
+    """
+    # Make sure, that at least one kernel is installed
+    suffix = "rootfs_" + args.device
+    pmb.chroot.apk.install(args, ["device-" + args.device], suffix)
+
+    # Parse and verify the flavor argument
+    flavor = args.flavor
+    flavors = pmb.chroot.other.kernel_flavors_installed(args, suffix)
+    if flavor:
+        if flavor not in flavors:
+            raise RuntimeError("No kernel installed with flavor " + flavor + "!" +
+                               " Run 'pmbootstrap flasher list_flavors' to get a list.")
+        return flavor
+    if not len(flavors):
+        raise RuntimeError(
+            "No kernel flavors installed in chroot " + suffix + "! Please let"
+            " your device package depend on a package starting with 'linux-'.")
+    return flavors[0]
+
+
 def _parse_suffix(args):
     if args.rootfs:
         return "rootfs_" + args.device

--- a/pmb/install/recovery.py
+++ b/pmb/install/recovery.py
@@ -27,6 +27,8 @@ def create_zip(args, suffix):
     """
     zip_root = "/var/lib/postmarketos-android-recovery-installer/"
     rootfs = "/mnt/rootfs_" + args.device
+    flavor = pmb.chroot.other.kernel_flavor_autodetect(args,
+                                                       "rootfs_" + args.device)
 
     # Install recovery installer package in buildroot
     pmb.chroot.apk.install(args,
@@ -52,7 +54,7 @@ def create_zip(args, suffix):
         # Move config file from /tmp/ to zip root
         ["mv", "/tmp/install_options", "install_options"],
         # Copy boot.img to zip root
-        ["cp", rootfs + "/boot/boot.img-" + args.device, "boot.img"],
+        ["cp", rootfs + "/boot/boot.img-" + flavor, "boot.img"],
         # Create tar archive of the rootfs
         ["tar", "-pczf", "rootfs.tar.gz", "--exclude", "./home/user/*",
          "-C", rootfs, "."],

--- a/pmb/install/recovery.py
+++ b/pmb/install/recovery.py
@@ -19,6 +19,7 @@ along with pmbootstrap.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 
 import pmb.chroot
+from pmb.flasher.frontend import parse_flavor_arg
 
 
 def create_zip(args, suffix):
@@ -27,8 +28,7 @@ def create_zip(args, suffix):
     """
     zip_root = "/var/lib/postmarketos-android-recovery-installer/"
     rootfs = "/mnt/rootfs_" + args.device
-    flavor = pmb.chroot.other.kernel_flavor_autodetect(args,
-                                                       "rootfs_" + args.device)
+    flavor = parse_flavor_arg(args)
 
     # Install recovery installer package in buildroot
     pmb.chroot.apk.install(args,

--- a/pmb/install/recovery.py
+++ b/pmb/install/recovery.py
@@ -19,7 +19,7 @@ along with pmbootstrap.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 
 import pmb.chroot
-from pmb.flasher.frontend import parse_flavor_arg
+import pmb.helpers.frontend
 
 
 def create_zip(args, suffix):
@@ -28,7 +28,7 @@ def create_zip(args, suffix):
     """
     zip_root = "/var/lib/postmarketos-android-recovery-installer/"
     rootfs = "/mnt/rootfs_" + args.device
-    flavor = parse_flavor_arg(args)
+    flavor = pmb.helpers.frontend._parse_flavor(args)
 
     # Install recovery installer package in buildroot
     pmb.chroot.apk.install(args,

--- a/pmb/parse/arguments.py
+++ b/pmb/parse/arguments.py
@@ -194,7 +194,7 @@ def arguments():
                          action="store_false", dest="full_disk_encryption")
     install.add_argument("--flavor",
                          help="Specify kernel flavor to include in recovery"
-                              "flashable zip", default=None)
+                              " flashable zip", default=None)
     install.add_argument("--android-recovery-zip",
                          help="generate TWRP flashable zip",
                          action="store_true", dest="android_recovery_zip")

--- a/pmb/parse/arguments.py
+++ b/pmb/parse/arguments.py
@@ -192,6 +192,9 @@ def arguments():
                          " added to the rootfs (e.g. 'vim,gcc')")
     install.add_argument("--no-fde", help="do not use full disk encryption",
                          action="store_false", dest="full_disk_encryption")
+    install.add_argument("--flavor",
+                         help="Specify kernel flavor to include in recovery"
+                              "flashable zip", default=None)
     install.add_argument("--android-recovery-zip",
                          help="generate TWRP flashable zip",
                          action="store_true", dest="android_recovery_zip")


### PR DESCRIPTION
Fixes #490 

Although not sure, what happens, when you have multiple flavors installed in the device rootfs chroot.
Is that a normal case?