### PR TITLE
Fix confusing error message for invalid makedepends

### DIFF
--- a/pmb/parse/depends.py
+++ b/pmb/parse/depends.py
@@ -25,7 +25,7 @@ import pmb.parse.apkindex
 def recurse_error_message(pkgname, in_aports, in_apkindexes):
     ret = "Could not find package '" + pkgname + "'"
     if in_aports:
-        ret += " aport"
+        ret += " in the aports folder"
         if in_apkindexes:
             ret += " and could not find it"
     if in_apkindexes:
@@ -64,6 +64,7 @@ def recurse(args, pkgnames, arch=None, in_apkindexes=True, in_aports=True,
         # Get depends and pkgname from aports
         logging.verbose("Get dependencies of: " + pkgname_depend)
         depends = None
+        pkgname = None
         if in_aports:
             aport = pmb.build.find_aport(args, pkgname_depend, False)
             if aport:
@@ -88,7 +89,7 @@ def recurse(args, pkgnames, arch=None, in_apkindexes=True, in_aports=True,
         if pkgname is None and strict:
             raise RuntimeError(
                 recurse_error_message(
-                    pkgname,
+                    pkgname_depend,
                     in_aports,
                     in_apkindexes))
 


### PR DESCRIPTION
I ran into this, and I think @PureTryOut and @craftyguy did also have this issue?

---

This happens currently, when a makedepend is invalid:

```
Traceback (most recent call last):
  File "/home/user/code/pmbootstrap/pmb/__init__.py", line 53, in main
    getattr(frontend, args.action)(args)
  File "/home/user/code/pmbootstrap/pmb/helpers/frontend.py", line 84, in build
    args.buildinfo)
  File "/home/user/code/pmbootstrap/pmb/build/package.py", line 62, in package
    pmb.chroot.apk.install(args, apkbuild["makedepends"], suffix)
  File "/home/user/code/pmbootstrap/pmb/chroot/apk.py", line 197, in install
    strict=True)
  File "/home/user/code/pmbootstrap/pmb/parse/depends.py", line 88, in recurse
    if pkgname is None and strict:
UnboundLocalError: local variable 'pkgname' referenced before assignment
```

With this patch, you get the meaning full error that should have been printed instead:
> ERROR: Could not find package 'invalid-package' in the aports folder and could not find it in any APKINDEX