### PR TITLE
Allow package names that have a + (plus sign) or . (period) in them

### DIFF
--- a/pmb/config/init.py
+++ b/pmb/config/init.py
@@ -121,7 +121,7 @@ def init(args):
                  " or \"none\"")
     cfg["pmbootstrap"]["extra_packages"] = pmb.helpers.cli.ask(args, "Extra packages",
                                                                None, args.extra_packages,
-                                                               validation_regex="^(|[-\w\s]+(?:,[-\w\s]*)*)$")
+                                                               validation_regex="^(|[-\w\s]+(?:,[-.+\w\s]*)*)$")
 
     # Do not save aports location to config file
     del cfg["pmbootstrap"]["aports"]

--- a/pmb/config/init.py
+++ b/pmb/config/init.py
@@ -121,7 +121,7 @@ def init(args):
                  " or \"none\"")
     cfg["pmbootstrap"]["extra_packages"] = pmb.helpers.cli.ask(args, "Extra packages",
                                                                None, args.extra_packages,
-                                                               validation_regex="^(|[-\w\s]+(?:,[-.+\w\s]*)*)$")
+                                                               validation_regex="^(|[-.+\w\s]+(?:,[-.+\w\s]*)*)$")
 
     # Do not save aports location to config file
     del cfg["pmbootstrap"]["aports"]


### PR DESCRIPTION
I have updated the regex in `./pmbootstrap.py init` to allow package names that contain a + or . character.

e.g. `Extra packages [none]: g++,cmake,gtk+2.0-dev,git`

Please see #548 for further details.