### PR TITLE
weston: add a patch to force FBIOPUT on Qualcomm devices

### DIFF
--- a/aports/main/weston/0007-compsitor-fbdev-add-Force-FBIOPUT-workaround-for-MSM.patch
+++ b/aports/main/weston/0007-compsitor-fbdev-add-Force-FBIOPUT-workaround-for-MSM.patch
@@ -1,0 +1,102 @@
+From 45e92a17c7006d36a54bfbc2f4a35281fbd7b58c Mon Sep 17 00:00:00 2001
+From: Zhuowei Zhang <zhuoweizhang@yahoo.com>
+Date: Mon, 11 Sep 2017 11:13:18 -0400
+Subject: [PATCH] compsitor-fbdev: add Force FBIOPUT workaround for MSM
+ framebuffer
+
+Qualcomm MSM devices have a framebuffer that only updates the display after
+a FBIOPUT, as they are intended for double buffered operation only.
+Add a hack to do a FBIOGET/FBIOPUT pair every frame to force an update.
+---
+ libweston/compositor-fbdev.c | 40 +++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 39 insertions(+), 1 deletion(-)
+
+diff --git a/libweston/compositor-fbdev.c b/libweston/compositor-fbdev.c
+index b7d2c74..bce8d68 100644
+--- a/libweston/compositor-fbdev.c
++++ b/libweston/compositor-fbdev.c
+@@ -75,6 +75,8 @@ struct fbdev_screeninfo {
+ 
+ 	pixman_format_code_t pixel_format; /* frame buffer pixel format */
+ 	unsigned int refresh_rate; /* Hertz */
++	int fb_fd; /* required for force_fbioput */
++	bool force_fbioput; /* force a FBIOPUT_VSCREENINFO after every frame; required by Qualcomm framebuffer */
+ };
+ 
+ struct fbdev_output {
+@@ -141,6 +143,21 @@ fbdev_output_repaint(struct weston_output *base, pixman_region32_t *damage,
+ 	 * refresh rate is given in mHz and the interval in ms. */
+ 	wl_event_source_timer_update(output->finish_frame_timer,
+ 	                             1000000 / output->mode.refresh);
++	if (output->fb_info.force_fbioput) {
++		/* Qualcomm's framebuffer only supports double buffering,
++		 * where after every frame the application performs a FBIOPUT_VSCREENINFO
++		 * to flip buffers. Since we don't double buffer, just grab the existing screeninfo.
++		 */
++		struct fb_var_screeninfo varinfo;
++		if (ioctl(output->fb_info.fb_fd, FBIOGET_VSCREENINFO, &varinfo) < 0) {
++			weston_log("force FBIOPUT: Failed to get screeninfo after repaint\n");
++			return 0;
++		}
++		if (ioctl(output->fb_info.fb_fd, FBIOPUT_VSCREENINFO, &varinfo) < 0) {
++			weston_log("force FBIOPUT: Failed to put screeninfo after repaint\n");
++			return 0;
++		}
++	}
+ 
+ 	return 0;
+ }
+@@ -272,6 +289,17 @@ calculate_refresh_rate(struct fb_var_screeninfo *vinfo)
+ 	return 60 * 1000; /* default to 60 Hz */
+ }
+ 
++static bool
++is_msm_framebuffer(const char *id) {
++	/*
++	 * Based on TWRP's Qualcomm detection:
++	 * https://github.com/omnirom/android_bootable_recovery/blob/
++	 * b523650c8ecb6751409120a38e52a66a3e48753f/minuitwrp/graphics_overlay.cpp#L101
++	 */
++	return !strncmp("msmfb", id, sizeof("msmfb") - 1) ||
++		!strncmp("mdssfb", id, sizeof("mdssfb") - 1);
++}
++
+ static int
+ fbdev_query_screen_info(struct fbdev_output *output, int fd,
+                         struct fbdev_screeninfo *info)
+@@ -300,6 +328,11 @@ fbdev_query_screen_info(struct fbdev_output *output, int fd,
+ 	info->pixel_format = calculate_pixman_format(&varinfo, &fixinfo, output->base.pixman_type);
+ 	info->refresh_rate = calculate_refresh_rate(&varinfo);
+ 
++	/* On Qualcomm devices, enable force fbioput. */
++	info->force_fbioput = is_msm_framebuffer(info->id);
++	info->fb_fd = fd;
++	weston_log("Force FBIOPUT workaround for Qualcomm framebuffer is %s\n", info->force_fbioput? "enabled" : "disabled");
++
+ 	if (info->pixel_format == 0) {
+ 		weston_log("Frame buffer uses an unsupported format.\n");
+ 		return -1;
+@@ -418,7 +451,7 @@ out_unmap:
+ 		fbdev_frame_buffer_destroy(output);
+ 
+ out_close:
+-	if (fd >= 0)
++	if (fd >= 0 && !(output->fb_info.force_fbioput && retval == 0)) /* keep fd open if fbioput */
+ 		close(fd);
+ 
+ 	return retval;
+@@ -434,6 +467,11 @@ fbdev_frame_buffer_destroy(struct fbdev_output *output)
+ 		           strerror(errno));
+ 
+ 	output->fb = NULL;
++	if (output->fb_info.force_fbioput) {
++		/* Close the framebuffer fd if we needed it for ioctls.
++		 * In normal mode we don't need this as it was already closed after mmap. */
++		close(output->fb_info.fb_fd);
++	}
+ }
+ 
+ static void fbdev_output_destroy(struct weston_output *base);
+-- 
+1.9.1
+

--- a/aports/main/weston/APKBUILD
+++ b/aports/main/weston/APKBUILD
@@ -7,7 +7,7 @@
 pkgname=weston
 pkgver=9999
 _pkgver=3.0.0
-pkgrel=5
+pkgrel=6
 _libname=lib$pkgname
 _libdir=$_libname-${_pkgver%%.*}
 pkgdesc="The reference Wayland server"
@@ -39,6 +39,7 @@ source="
 	0004-musl-weston-launcher.patch
 	0005-timespec.patch
 	0006-compositor-fbdev-fix-start-up-assertion.patch
+	0007-compsitor-fbdev-add-Force-FBIOPUT-workaround-for-MSM.patch
 "
 builddir="$srcdir/$pkgname-$_pkgver"
 
@@ -139,4 +140,5 @@ fa1099258aaef38f228de2e9ca3e2ae5e9e21ed10891f8686f5abd16d7f6bc6c57e43e0bfc3175ed
 b5eb741ea8b6fcbd9de95e773fe0bf4ae6588ef57564f97a65aefc6c7ec29f1a01de9764a25672fd7c76c8ff514b497743cbaf279818123041c161c7a1e62bb6  0003-compositor-fbdev-print-the-pixman-type-guessed-in-ca.patch
 856a28a324cb9adf94b92bf5489ff43827d57e6acee0c7e0e558018357166b782126e086a4308c3e3499d068fa07f02862cc20cdfbc9a3d6af30ec823eb1b78f  0004-musl-weston-launcher.patch
 3e596af4bf0a6b06a5d28376043db111fe1c161ead04501fa6d2c667b5a21889cca3354d1bdc4ac794841bef68ed5e1a7a84e44e7d510e947e3673195706caed  0005-timespec.patch
-5d356bc8534c5486b0c5daf727fb8d2cd8409f7f964e3f391c225a2b21b9f293e36d10344f55f0e6566bfbde415c990a72d57fe5db6081acd3c788106cda319f  0006-compositor-fbdev-fix-start-up-assertion.patch"
+5d356bc8534c5486b0c5daf727fb8d2cd8409f7f964e3f391c225a2b21b9f293e36d10344f55f0e6566bfbde415c990a72d57fe5db6081acd3c788106cda319f  0006-compositor-fbdev-fix-start-up-assertion.patch
+fb7ca42dfd00e946f70efbb3c093eb360ce6f41d7a19a3b75becfc51461531ef5b8fc6b13556967ce8f0bfd6dd940b808e8ac581a172f61827acab2ea16d08d5  0007-compsitor-fbdev-add-Force-FBIOPUT-workaround-for-MSM.patch"


### PR DESCRIPTION
Qualcomm's framebuffer is designed for double buffering, and only updates the screen
after an FBIOPUT ioctl is submitted to flip the buffer. Detect this to force Weston
to send this ioctl at the end of every frame even when single buffering.

This should be equivalent to the
`cat /sys/class/graphics/fb0/modes > /sys/class/graphics/fb0/mode`
hack.

This is tested on Nexus 6P (angler), and Weston is able to correctly draw the screen without the cat modes hack. On non-Qualcomm devices, this shouldn't activate, but I haven't tested there.

Edit: for testers: in /tmp/weston.log, if you have a device that needed the cat modes hack, applying this should say
`Force FBIOPUT workaround for Qualcomm framebuffer is enabled`
for other devices it should say
`Force FBIOPUT workaround for Qualcomm framebuffer is disabled`