### PR TITLE
zap: add `-d`/`--distfiles` argument to clear downloaded files cache

### DIFF
--- a/pmb/chroot/zap.py
+++ b/pmb/chroot/zap.py
@@ -24,7 +24,7 @@ import pmb.chroot
 import pmb.helpers.run
 
 
-def zap(args, confirm=True, packages=False, http=False, mismatch_bins=False):
+def zap(args, confirm=True, packages=False, http=False, mismatch_bins=False, distfiles=False):
     """
     Shutdown everything inside the chroots (e.g. distccd, adb), umount
     everything and then safely remove folders from the work-directory.
@@ -33,6 +33,7 @@ def zap(args, confirm=True, packages=False, http=False, mismatch_bins=False):
     :arg http: Clear the http cache (used e.g. for the initial apk download)
     :arg mismatch_bins: Remove the packages, that have a different version
                         compared to what is in the abuilds folder.
+    :arg distfiles: Clear the downloaded files cache
 
     NOTE: This function gets called in pmb/config/init.py, with only args.work
     and args.device set!
@@ -49,6 +50,8 @@ def zap(args, confirm=True, packages=False, http=False, mismatch_bins=False):
         patterns += ["packages"]
     if http:
         patterns += ["cache_http"]
+    if distfiles:
+        patterns += ["cache_distfiles"]
 
     # Delete everything matching the patterns
     for pattern in patterns:

--- a/pmb/helpers/frontend.py
+++ b/pmb/helpers/frontend.py
@@ -195,4 +195,4 @@ def log_distccd(args):
 
 def zap(args):
     pmb.chroot.zap(args, packages=args.packages, http=args.http,
-                   mismatch_bins=args.mismatch_bins)
+                   mismatch_bins=args.mismatch_bins, distfiles=args.distfiles)

--- a/pmb/parse/arguments.py
+++ b/pmb/parse/arguments.py
@@ -172,6 +172,8 @@ def arguments():
     zap.add_argument("-m", "--mismatch-bins", action="store_true", help="also delete"
                      " binary packages that are newer than the corresponding"
                      " package in aports")
+    zap.add_argument("-d", "--distfiles", action="store_true", help="also delete"
+                     " downloaded files cache")
 
     # Action: stats
     stats = sub.add_parser("stats", help="show ccache stats")


### PR DESCRIPTION
Useful usecases:
- download again the external files to verify the checksum is correct
- free some space (when someone change the external source, previous downloaded file remains there)