### PR TITLE
Corrected small typo in ~/pmbootstrap/pmb/config/init.py

### DIFF
--- a/aports/device/device-samsung-ypg1/90-android-touch-dev.rules
+++ b/aports/device/device-samsung-ypg1/90-android-touch-dev.rules
@@ -1,0 +1,8 @@
+# udev rules file
+# All device names can be read from weston's logfile (/tmp/weston.log in postmarketOS)
+
+# Touchscreen (use 'weston-calibrator' to calibrate)
+SUBSYSTEM=="input", ATTRS{name}=="sec_touchscreen", \
+ENV{ID_INPUT}="1", ENV{ID_INPUT_TOUCHSCREEN}="1" \
+ENV{WL_CALIBRATION}="0.954174 0.016888 -2.626083 -0.006031 1.011271 14.175903"
+

--- a/aports/device/device-samsung-ypg1/APKBUILD
+++ b/aports/device/device-samsung-ypg1/APKBUILD
@@ -1,0 +1,32 @@
+pkgname=device-samsung-ypg1
+pkgver=1
+pkgrel=11
+pkgdesc="Samsung Galaxy Player 4.0"
+url="https://github.com/postmarketOS"
+arch="noarch"
+license="MIT"
+depends="linux-samsung-i9100 firmware-samsung-i9100 libsamsung-ipc"
+makedepends=""
+install="$pkgname.post-install"
+subpackages=""
+source="
+	deviceinfo
+	90-android-touch-dev.rules
+	$install
+"
+options="!check"
+
+build() {
+	return 0
+}
+
+package() {
+	install -D -m644 "$srcdir/deviceinfo" \
+		"$pkgdir/etc/deviceinfo"
+	install -D -m644 "$srcdir"/90-android-touch-dev.rules \
+		"$pkgdir"/etc/udev/rules.d/90-android-touch-dev.rules
+}
+
+sha512sums="97504a82ce4c9a8177f7ae7c83ff01262bcd91f707f63ac369f4553f72341cd3b0b813151f28c4873012bb36ac324cf11954d21621df66dc13ad8c904f72b257  deviceinfo
+8aead706ddb118a44de7d049f07d10a27e727d17724058d132e4ec4fa73fed29c9ccfe03f02aca459c922ec0fbba24e171fe3c76e33f7c5462631e3dd5506e36  90-android-touch-dev.rules
+03da52725e676bc7db371cbf4b60bff8689eca469dae96a02ca7d6c194ed9f8c4ec9d19d1ac9212eeba0b73384fd213e86f2b93da94f37e5abe4cc3339281205  device-samsung-ypg1.post-install"

--- a/aports/device/device-samsung-ypg1/device-samsung-ypg1.post-install
+++ b/aports/device/device-samsung-ypg1/device-samsung-ypg1.post-install
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Create mount point and /efs mount point in fstab
+if [ -z "$(grep /efs /etc/fstab)" ]; then
+	mkdir -p /efs
+	echo "/dev/mmcblk0p1	/efs	auto	ro	0	0" >> /etc/fstab
+fi

--- a/aports/device/device-samsung-ypg1/deviceinfo
+++ b/aports/device/device-samsung-ypg1/deviceinfo
@@ -1,0 +1,27 @@
+# Reference: <https://postmarketos.org/deviceinfo>
+# Please use double quotes only. You can source this file in shell scripts.
+
+deviceinfo_format_version="0"
+deviceinfo_name="Galaxy Player 4.0"
+deviceinfo_manufacturer="Samsung"
+deviceinfo_date=""
+deviceinfo_keyboard="false"
+deviceinfo_nonfree="????"
+deviceinfo_dtb=""
+deviceinfo_modules_initfs=""
+deviceinfo_external_disk="true"
+deviceinfo_external_disk_install="true"
+deviceinfo_flash_methods="heimdall-isorec"
+deviceinfo_arch="armhf"
+
+# Splash screen
+deviceinfo_screen_width="480"
+deviceinfo_screen_height="800"
+
+# Heimdall related
+deviceinfo_flash_heimdall_partition_kernel="KERNEL"
+deviceinfo_flash_heimdall_partition_initfs="RECOVERY"
+deviceinfo_flash_heimdall_partition_system="FACTORYFS"
+
+deviceinfo_weston_core_modules="xwayland.so"
+

--- a/aports/device/device-samsung-ypg1/initfs-hook.sh
+++ b/aports/device/device-samsung-ypg1/initfs-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# set framebuffer resolution
+cat /sys/class/graphics/fb0/modes > /sys/class/graphics/fb0/mode

--- a/pmb/config/init.py
+++ b/pmb/config/init.py
@@ -140,7 +140,7 @@ def init(args):
 
     logging.info(
         "WARNING: The applications in the chroots do not get updated automatically.")
-    logging.info("Run 'pmbootstrap zap' to delete all chroots once a day before"
+    logging.info("Run 'pmbootstrap.py zap' to delete all chroots once a day before"
                  " working with pmbootstrap!")
     logging.info("It only takes a few seconds, and all packages are cached.")
 


### PR DESCRIPTION
 Instead of "pmbootstrap zap" to delete chroots, it needs the full filename pmbootstrap.py. Hence it's missing ".py" on line 143.