### PR TITLE
[gtk+2.0-maemo] add missing py-six makedepend

### DIFF
--- a/aports/maemo/gtk+2.0-maemo/APKBUILD
+++ b/aports/maemo/gtk+2.0-maemo/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=gtk+2.0-maemo
 pkgver=2.24.31
-pkgrel=0
+pkgrel=1
 subpkg=gtk-update-icon-cache
 pkgdesc="The GTK+ Toolkit (v2)"
 url="http://www.gtk.org/"
@@ -43,7 +43,8 @@ makedepends="
 	libxfixes-dev
 	libxrandr-dev
 	libxi-dev
-	zlib-dev"
+	zlib-dev
+	py-six"
 source="http://ftp.gnome.org/pub/gnome/sources/gtk+/${pkgver%.*}/gtk+-$pkgver.tar.xz
 	https://raw.githubusercontent.com/fremantle-gtk2/gtk/2.24.25-3m7%2Bmaemo/debian/patches/hildonize-gdk-window.diff
 	https://raw.githubusercontent.com/fremantle-gtk2/gtk/2.24.25-3m7%2Bmaemo/debian/patches/hildonize-gtk-container.diff


### PR DESCRIPTION
Fixes #618 