### PR TITLE
pmbootstrap: support native cross compile for Autoconf packages

### DIFF
--- a/pmb/build/autodetect.py
+++ b/pmb/build/autodetect.py
@@ -42,7 +42,7 @@ def carch(args, apkbuild, carch, strict=False):
     return apkbuild["arch"][0]
 
 
-def suffix(args, apkbuild, carch):
+def suffix(args, apkbuild, carch, strict):
     if carch == args.arch_native:
         return "native"
 
@@ -50,7 +50,10 @@ def suffix(args, apkbuild, carch):
     if pkgname.endswith("-repack"):
         return "native"
     if args.cross:
-        for pattern in pmb.config.build_cross_native:
+        build_cross_native = pmb.config.build_cross_native
+        if strict or args.prefer_distcc_cross:
+            build_cross_native = pmb.config.build_cross_native_nodeps
+        for pattern in build_cross_native:
             if fnmatch.fnmatch(pkgname, pattern):
                 return "native"
 
@@ -70,3 +73,14 @@ def crosscompile(args, apkbuild, carch, suffix):
     if suffix == "native":
         return "native"
     return "distcc"
+
+
+def is_cross_native_nodeps(apkbuild):
+    """
+        Checks if a package is in the build_cross_native_nodeps list.
+    """
+    pkgname = apkbuild["pkgname"]
+    for pattern in pmb.config.build_cross_native_nodeps:
+        if fnmatch.fnmatch(pkgname, pattern):
+            return True
+    return False

--- a/pmb/build/package.py
+++ b/pmb/build/package.py
@@ -62,7 +62,9 @@ def package(args, pkgname, carch, force=False, buildinfo=False, strict=False):
     if native_cross_with_deps:
         pmb.build.init(args, "buildroot_" + carch)
     if len(apkbuild["makedepends"]):
+        # build: install in build chroot
         makedepends_build = apkbuild["makedepends"]
+        # host: install in foreign sysroot if cross compiling
         makedepends_host = []
         if native_cross_with_deps:
             if len(apkbuild["makedepends_build"]) != 0 and len(apkbuild["makedepends_host"]) != 0:
@@ -80,7 +82,7 @@ def package(args, pkgname, carch, force=False, buildinfo=False, strict=False):
         else:
             pmb.chroot.apk.install(args, makedepends_build, suffix)
             if len(makedepends_host) != 0:
-                pmb.chroot.apk.install(args, makedepends_build, "buildroot_" + carch)
+                pmb.chroot.apk.install(args, makedepends_host, "buildroot_" + carch)
 
     if cross:
         pmb.chroot.apk.install(args, ["gcc-" + carch_buildenv,

--- a/pmb/config/__init__.py
+++ b/pmb/config/__init__.py
@@ -132,7 +132,7 @@ build_packages = ["abuild", "build-base", "ccache"]
 
 # fnmatch for supported pkgnames, that can be directly compiled inside
 # the native chroot and a cross-compiler, without using distcc
-build_cross_native = ["linux-*"]
+build_cross_native = ["linux-*", "chocolate-doom"]
 
 # Necessary kernel config options
 necessary_kconfig_options = {

--- a/pmb/config/__init__.py
+++ b/pmb/config/__init__.py
@@ -132,7 +132,7 @@ build_packages = ["abuild", "build-base", "ccache"]
 
 # fnmatch for supported pkgnames, that can be directly compiled inside
 # the native chroot and a cross-compiler, without using distcc
-build_cross_native = ["linux-*", "chocolate-doom"]
+build_cross_native = ["linux-*", "chocolate-doom", "weston"]
 
 # Necessary kernel config options
 necessary_kconfig_options = {

--- a/pmb/config/__init__.py
+++ b/pmb/config/__init__.py
@@ -64,7 +64,8 @@ defaults = {
     # A higher value is typically desired, but this can lead to VERY long open
     # times on slower devices due to host systems being MUCH faster than the
     # target device: <https://github.com/postmarketOS/pmbootstrap/issues/429>
-    "iter_time": "200"
+    "iter_time": "200",
+    "prefer_distcc_cross": False,
 }
 
 #
@@ -132,7 +133,11 @@ build_packages = ["abuild", "build-base", "ccache"]
 
 # fnmatch for supported pkgnames, that can be directly compiled inside
 # the native chroot and a cross-compiler, without using distcc
-build_cross_native = ["linux-*", "chocolate-doom", "weston"]
+build_cross_native = ["linux-*", "weston"]
+
+# fnmatch for supported pkgnames, that can be directly compiled inside
+# the native chroot and a cross-compiler, without using distcc or any dependencies
+build_cross_native_nodeps = ["linux-*"]
 
 # Necessary kernel config options
 necessary_kconfig_options = {


### PR DESCRIPTION
Note: this PR depends on #664, so its commits are duplicated in the changes list. Only the last commit is specific to this PR.

This commit adds support for cross-compiling Autotools-based packages without distcc and qemu. This should be faster and more reliable.

See #659 for more information.

This installs dependencies in the foreign arch chroot, then bind mounts the foreign chroot into the native chroot for a cross compile sysroot. Finally, this sets env variables to trigger a cross compile based on https://dev.alpinelinux.org/~tteras/bootstrap/abuild-crossbuild-aarch64.conf

Currently chocolate-doom is the only Autotools package whitelisted to build using this configuration, and the executable it builds for aarch64 seems to at least start (inside the aarch64 build chroot, not tested on device; don't have a Doom WAD handy to test with)

====

Other changes I need to do:

- [ ] Do I need to install makedepends in the builder root as well as in the target root? Does the target root ever need the makedepends packages? 

Note: some packages in upstream aports have both a makedepends_host and makedepends_build variable, which is used by abuild to install the correct packages to each sysroot. However, the kernel sources do not.

- [ ] Make sure kernels still build
- [ ] Whitelist a few more packages and compare builds - can pmbootstrap's compare function work for this?
- [ ] Switch to a heuristic for whitelisting packages (maybe anything containing `./configure --host=$(HOST)` or something?) - should probably be controlled by a config var?
- [ ] Think of a way to warn when someone submits an APKBUILD that wouldn't work for cross compile?

Please suggest test cases!