### PR TITLE
Add mkfs.ext2 and mkfs.ext4 binaries to the android-recovery-installer

### DIFF
--- a/aports/main/postmarketos-android-recovery-installer/APKBUILD
+++ b/aports/main/postmarketos-android-recovery-installer/APKBUILD
@@ -1,10 +1,10 @@
 pkgname=postmarketos-android-recovery-installer
-pkgver=0.0.4
+pkgver=0.0.5
 pkgrel=0
 pkgdesc="TWRP compatible postmarketOS installer script"
 url="https://github.com/postmarketOS"
 # multipath-tools: kpartx
-depends="busybox-extras lddtree cryptsetup multipath-tools device-mapper parted util-linux zip"
+depends="busybox-extras lddtree cryptsetup multipath-tools device-mapper parted util-linux zip e2fsprogs"
 source="build_zip.sh
 	update-binary
 	pmos_install
@@ -26,8 +26,8 @@ package() {
 	done
 	mkdir "$pkgdir/var/lib/postmarketos-android-recovery-installer/lib/"
 }
-sha512sums="d065577f587ee604cfa635c3eaba5c856800e9dafbbab65d4311dc89b72feab131fc23605bc0a344979f0760162bc509ac2056ee3c4d3e78e56be15032e314c1  build_zip.sh
+sha512sums="7f58f54c648f67cc7818de6a5c73f0c998101ddb06987c88d7612e406fed25e16fbae53f46ee81249eb1a7ebc1ea0e4ec43493d6b7bbcea43684d1b8d40649ef  build_zip.sh
 156f889593d82d4b1c88f3873299fc054e70e78bf26af37af4dd7770ed31a0a581f2cf03cad9e11a60159f424d2d3869fd6cd28600ad305469ddf01eaff49f6c  update-binary
-8d888a7468e4e316c213911fcde60134f10c875dd21fcf95a7c3f805df1e90bada69553b595f5f74be0d8d48524c0a08f85ee7b1062b03675d1d0429bf7fd2f8  pmos_install
+34f3ebc81c95c3f0583748cd14ca63d657946327a6bf999cb07448516123aac17f243d13db2101a44514f6eeb7e07b9def60b32c32650f3ecc0452e98e566d54  pmos_install
 b4c669ab6dfe330a30c575f864cea916ac357ae96547c2296d1b5399669c6f49570c60554985d2939a1d3e3cb464e3229e2b4724eba1dd5d920dcec1b0f7f0e3  pmos_install_functions
 27dd89aa8471349995a1cbbc1034ead662a0d1dd70ca5490f3191ceaaeb853331003c20ffddbbd95fe822135a85c1beb1e2a32bb33b10c2a4177b30347a40555  pmos_setpw"

--- a/aports/main/postmarketos-android-recovery-installer/build_zip.sh
+++ b/aports/main/postmarketos-android-recovery-installer/build_zip.sh
@@ -43,7 +43,7 @@ check_whether_exists()
 # shellcheck disable=SC1091
 . ./install_options
 
-BINARIES="/sbin/cryptsetup /sbin/kpartx /usr/sbin/parted /usr/sbin/partprobe /sbin/findfs"
+BINARIES="/sbin/cryptsetup /sbin/kpartx /usr/sbin/parted /usr/sbin/partprobe /sbin/findfs /sbin/mkfs.ext2 /sbin/mkfs.ext4"
 # shellcheck disable=SC2086
 LIBRARIES=$(lddtree -l $BINARIES | awk '/lib/ {print}' | sort -u)
 copy_files "$BINARIES" bin/

--- a/aports/main/postmarketos-android-recovery-installer/pmos_install
+++ b/aports/main/postmarketos-android-recovery-installer/pmos_install
@@ -77,12 +77,12 @@ then
 	ui_print "Opening LUKS partition..."
 	cryptsetup luksOpen -d "$WORKING_DIR"/lukskey "$ROOT_PARTITION" pm_crypt
 	ui_print "Formatting LUKS partition..."
-	make_ext4fs -L 'pmOS_root' /dev/mapper/pm_crypt
+	mkfs.ext4 -L 'pmOS_root' /dev/mapper/pm_crypt
 	ui_print "Mounting LUKS partition..."
 	mount -t ext4 -rw /dev/mapper/pm_crypt /"$INSTALL_PARTITION"
 else
 	ui_print "Formatting root partition..."
-	make_ext4fs -L 'pmOS_root' "$ROOT_PARTITION"
+	mkfs.ext4 -L 'pmOS_root' "$ROOT_PARTITION"
 	ui_print "Mounting root partition..."
 	mount -t ext4 -rw "$ROOT_PARTITION" /"$INSTALL_PARTITION"
 fi
@@ -93,7 +93,7 @@ mkdir /"$INSTALL_PARTITION"/boot
 mount -t ext2 -rw "$PMOS_BOOT" /"$INSTALL_PARTITION"/boot || {
 	ui_print "Failed to format/mount ext2 partition."
 	ui_print "Trying ext4..."
-	make_ext4fs -L 'pmOS_boot' "$PMOS_BOOT"
+	mkfs.ext4 -L 'pmOS_boot' "$PMOS_BOOT"
 	mount -t ext4 -rw "$PMOS_BOOT" /"$INSTALL_PARTITION"/boot
 }
 ui_print "Installing rootfs..."


### PR DESCRIPTION
Using the unofficial TWRP for the Huawey Y530 (no official support yet) I encountered this issue:
```
+ make_ext4fs -L pmOS_root /dev/mapper/pm_crypt
/tmp/postmarketos/bin/pmos_install: line 1: make_ext4fs: not found
```
I have no idea where the `make_ext4fs` command comes from but the mkfs.ext4 file was missing. 

This PR will ensure that both the necessary binaries to create the partitions are present.

All the other commands executed in the recovery script seems related to the busybox, if in the future there will be problems with that too, we may consider to extract all the files we need in a folder and chroot it (maybe reusing some functions from [init_functions.sh](https://github.com/postmarketOS/pmbootstrap/blob/d45c7d2d844be0da16d15c74c55a17b833d4f970/aports/main/postmarketos-mkinitfs/init_functions.sh)).