### PR TITLE
Add xfce4, including configuration that is suitable for touchscreen.

### DIFF
--- a/aports/main/postmarketos-ui-xfce4/APKBUILD
+++ b/aports/main/postmarketos-ui-xfce4/APKBUILD
@@ -1,0 +1,24 @@
+pkgname=postmarketos-ui-xfce4
+pkgver=0.0
+pkgrel=0
+pkgdesc="Meta package for xfce4"
+url="https://github.com/postmarketOS/xfce4-phone"
+arch="noarch"
+license="GPL3"
+depends="xfce4"
+makedepends=""
+install="$pkgname.post-install"
+subpackages=""
+source="start_xfce4.sh $install ${pkgname}-${pkgver}-${pkgrel}.tar.gz::https://github.com/postmarketOS/xfce4-phone/archive/${pkgver}.tar.gz"
+# g/tui/ofone/config.n900/xfce4/xfconf/xfce-perchannel-xml/
+options="!check"
+
+package() {
+	install -D -m644 "$srcdir"/start_xfce4.sh \
+		"$pkgdir"/etc/profile.d/start_xfce4.sh
+	install -d -m755 "$pkgdir"/etc/skel
+	cp -a "${srcdir}/xfce4-phone-${pkgver}"/config "$pkgdir"/etc/skel/.config
+}
+sha512sums="6aa496acf16a5348050ed7aca07203f20f4663b37acd63255c31561e0931f90886050aa3c221db2224e3dc357fe5329dc703ec06f5938e7cea8606ad6b741ee6  start_xfce4.sh
+86b0d3d83da393aafc5d17552457030d9dfae071a35dbe93125e101361962f1752575f17c7dd4140d2a5c6cd4e09367bb2226b532a0194c26c5a77899e80842f  postmarketos-ui-xfce4.post-install
+758562d2820a11b2c96e1805e00450f78203e6fd224115c373825f041b344985490a84b74d2880b423d5606140d5ffb41e79b0a8eb3e5b9a0ce7874c4ccfb666  postmarketos-ui-xfce4-0.0-0.tar.gz"

--- a/aports/main/postmarketos-ui-xfce4/APKBUILD
+++ b/aports/main/postmarketos-ui-xfce4/APKBUILD
@@ -10,7 +10,6 @@ makedepends=""
 install="$pkgname.post-install"
 subpackages=""
 source="start_xfce4.sh $install ${pkgname}-${pkgver}-${pkgrel}.tar.gz::https://github.com/postmarketOS/xfce4-phone/archive/${pkgver}.tar.gz"
-# g/tui/ofone/config.n900/xfce4/xfconf/xfce-perchannel-xml/
 options="!check"
 
 package() {

--- a/aports/main/postmarketos-ui-xfce4/postmarketos-ui-xfce4.post-install
+++ b/aports/main/postmarketos-ui-xfce4/postmarketos-ui-xfce4.post-install
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+. /etc/deviceinfo
+
+# Autologin on tty1, let busybox autoconfigure 2-6
+autologin="user"
+for i in 1 2 3 4 5 6; do
+	old="^tty$i::respawn:/sbin/getty 38400 tty$i"
+	new="# tty$i::respawn:/sbin/getty 38400 tty$i"
+	[ "$i" == "1" ] && new="tty1::respawn:/bin/login -f $autologin"
+	sed -i -e "s.$old.$new.g" /etc/inittab
+done
+

--- a/aports/main/postmarketos-ui-xfce4/start_xfce4.sh
+++ b/aports/main/postmarketos-ui-xfce4/start_xfce4.sh
@@ -1,0 +1,8 @@
+
+if [ "$(id -u)" = "12345" ] && [ "$(tty)" = "/dev/tty1" ]; then
+	startxfce4 > ~/x11.log 2>&1
+
+	# In case of failure, restart after 1s
+	sleep 1
+	exit
+fi


### PR DESCRIPTION
Nokia N900 does not have working hardware acceleration, so xfce4 with enlarged buttons is easiest way to usable user interface at the moment.