### PR TITLE
Fix #681: gnome-menus2 didn't compile for aarch64

### DIFF
--- a/aports/maemo/gnome-menus2/APKBUILD
+++ b/aports/maemo/gnome-menus2/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=gnome-menus2
 pkgver=3.0.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Library for the Desktop Menu Specification (legacy version)'
 arch="all"
 url='http://www.gnome.org/'
@@ -9,6 +9,12 @@ depends="glib"
 makedepends="gobject-introspection intltool python-dev glib-dev"
 subpackages="$pkgname-dev"
 source="http://ftp.gnome.org/pub/gnome/sources/${pkgname%2}/${pkgver%.*}/${pkgname%2}-${pkgver}.tar.bz2"
+
+prepare() {
+	default_prepare
+	update_config_sub
+	update_config_guess
+}
 
 build() {
     cd "$srcdir/${pkgname%2}-$pkgver"


### PR DESCRIPTION
### How to test
`pmbootstrap build --arch=aarch64 gnome-menus2`

It should run through. Without this PR it does not.