### PR TITLE
X11 screen rotation config for i9070

### DIFF
--- a/aports/device/device-samsung-i9070/APKBUILD
+++ b/aports/device/device-samsung-i9070/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=device-samsung-i9070
 pkgver=1
-pkgrel=12
+pkgrel=13
 pkgdesc="Samsung Galaxy S Advance"
 url="https://github.com/postmarketOS"
 arch="noarch"
@@ -8,12 +8,13 @@ license="MIT"
 depends="linux-samsung-i9070 firmware-samsung-i9070"
 makedepends=""
 install=""
-subpackages=""
+subpackages="$pkgname-x11"
 source="
 	deviceinfo
 	initfs-hook.sh
 	90-android-touch-dev.rules
 	modules-load.conf
+	x11-fbdev-rotate.conf
 "
 options="!check"
 
@@ -28,7 +29,14 @@ package() {
 		"$pkgdir"/etc/modules-load.d/00-${pkgname}.conf
 }
 
+x11() {
+	install_if="$pkgname xorg-server"
+	install -D -m644 "$srcdir/x11-fbdev-rotate.conf" \
+		"$subpkgdir"/etc/X11/xorg.conf.d/00-fbdev-rotate.conf
+}
+
 sha512sums="a71af1256822f5ad966433bff63a4f749eeae1c166a4613987f490362dbcc3031acb6e7380f35bbd07d6a410c7728fe5b355b18e0cf122902c4b8a90e6166e4c  deviceinfo
 098187f6ab56d2542f98f1b5fbcf493431f665a4300db05e859357366e39b02a3d508bfd94c1d1bd7c669261e7ef0d4e1aef1fdbb15541fe34f3f48a6caa247f  initfs-hook.sh
 ffa8ba47539f0b4a931c560811d7842c7f5270631066c270322859c1ef77e63fba09a8462c2533bd6d095056b2c7936c2d4fc4e225f3cff45169f121bf93d8ed  90-android-touch-dev.rules
-61e8becbf6fa7c1c6c42e481083f5981ae7af33a48cbc53e817d8ac2c6a8e4f67a54b32ae3b8f5f25f7b412165a849dc93a629110dc47b0d16927bf2a12eb7e1  modules-load.conf"
+61e8becbf6fa7c1c6c42e481083f5981ae7af33a48cbc53e817d8ac2c6a8e4f67a54b32ae3b8f5f25f7b412165a849dc93a629110dc47b0d16927bf2a12eb7e1  modules-load.conf
+7b05ac71c2255fc0768d1b93761166ab749c1499d43845482cbbb5792b8482a55e3e6ededf8cc99a254c2c1ecceae07faaf4a025154b4a95060d5c46a203e1c6  x11-fbdev-rotate.conf"

--- a/aports/device/device-samsung-i9070/x11-fbdev-rotate.conf
+++ b/aports/device/device-samsung-i9070/x11-fbdev-rotate.conf
@@ -1,0 +1,5 @@
+Section "Device"
+  Identifier "LCD"
+  Driver "fbdev"
+  Option "Rotate" "CW"
+EndSection


### PR DESCRIPTION
@drebrez, I simply took your config from https://github.com/postmarketOS/pmbootstrap/pull/649#issuecomment-333320142 and put it with `install_if` to `device-samsung-i9070`.

I am not sure if you need to have the screen rotated only for Hildon, or for all X11 desktops. So I'm not sure if this is the right way to handle it. What do you think?

Also feel free to put any commits on top of this branch, if you have a better solution 👍 