### PR TITLE
pmbootstrap: enable ccache when using distcc to cross compile

### DIFF
--- a/pmb/build/package.py
+++ b/pmb/build/package.py
@@ -100,7 +100,7 @@ def package(args, pkgname, carch, force=False, buildinfo=False, strict=False):
         env["CROSS_COMPILE"] = hostspec + "-"
         env["CC"] = hostspec + "-gcc"
     if cross == "distcc":
-        env["PATH"] = "/usr/lib/distcc/bin:" + pmb.config.chroot_path
+        env["PATH"] = pmb.config.chroot_path.replace("/usr/lib/ccache/bin", "/usr/lib/ccache/bin:/usr/lib/distcc/bin")
         env["DISTCC_HOSTS"] = "127.0.0.1:" + args.port_distccd
     for key, value in env.items():
         cmd += [key + "=" + value]


### PR DESCRIPTION
Based on https://wiki.gentoo.org/wiki/Distcc#With_automake.

Compile time of weston is shortened from 11 minutes on first compile to 10 minutes on second.

This doesn't work for kwin, though - using this configuration cmake only builds with ccache and not distcc. Sigh. I don't known enough about cmake, distcc, and ccache: how would I start fixing this?

Note that I haven't checked if this actually speeds things up relative to the original code, and I'll rather not spend another 30 minutes building Weston, so I would really appreciate if someone can see if this actually has an effect.

This fixes issue #716.