### PR TITLE
aports: add kmscube for testing kernel modesetting

### DIFF
--- a/aports/main/kmscube/APKBUILD
+++ b/aports/main/kmscube/APKBUILD
@@ -1,0 +1,32 @@
+pkgname=kmscube
+pkgver=1.0
+pkgrel=0
+pkgdesc="Simple demo for testing kernel modesetting support"
+url="https://cgit.freedesktop.org/mesa/kmscube/"
+arch="all"
+license="MIT"
+depends="libdrm"
+makedepends="mesa-dev autoconf automake"
+_hash="0d8de4ce3a03f36af1817f9b0586d132ad2c5d2e"
+source="https://cgit.freedesktop.org/mesa/kmscube/snapshot/${_hash}.tar.gz"
+builddir="$srcdir/${_hash}"
+
+build(){
+	cd "$builddir"
+	./autogen.sh
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="5316973de5752aa02a10124900ffa92b950a045626ad68817515143e756da37c38dfaae18e3874791eca2aa094b7f51818dac60a44929c117177f65eea04d835  0d8de4ce3a03f36af1817f9b0586d132ad2c5d2e.tar.gz"


### PR DESCRIPTION
kmscube is a command line utility for testing KMS-capable GPU drivers, which may be useful for validating DRM rendering and OpenGL ES acceleration capabilities required by accelerated Weston/KWin on supported devices.

I don't have a KMS capable device to test, so I made sure this works by

- installing mesa-dri-intel in the chroot_native
- mounting my host /dev and /sys into chroot_native
- switching to a different VT on my (Intel Haswell integrated graphics) host
- running kmscube

which shows a spinning cube on screen.