### PR TITLE
Fix weston arguments

### DIFF
--- a/aports/main/postmarketos-ui-weston/APKBUILD
+++ b/aports/main/postmarketos-ui-weston/APKBUILD
@@ -18,5 +18,5 @@ package() {
 	install -D -m644 "$srcdir"/start_weston.sh \
 		"$pkgdir"/etc/profile.d/start_weston.sh
 }
-sha512sums="290d719e04f99905cc8eb4cfeee131e7993969ca3b40517ddf4f8fb4c5817d73d169a03e66aba85e4e330224ca39f2be1cff40a4a0fdab0ee2cb4f9124dd9d06  start_weston.sh
+sha512sums="1fb3dff37e7db7277f713958eeb9b9b8eae730aec2fe02d2c87d036d23b7f3a79779288f5ddf9a3b05465beea5410133fb4b0268b0544a07c08b9d53cdce4745  start_weston.sh
 066071c0fa1b35079c28dc18ce66ac56575d49df06f1a217e308ea0b4587436e76432817091737eb9a17e7eecfc855d4d488e5850c77ccbaa3ee4e6a3949dbb8  postmarketos-ui-weston.post-install"

--- a/aports/main/postmarketos-ui-weston/start_weston.sh
+++ b/aports/main/postmarketos-ui-weston/start_weston.sh
@@ -27,7 +27,7 @@ if test -z "${XDG_RUNTIME_DIR}"; then
 		) &
 
 
-		weston-launch ${WESTON_OPTS} >/tmp/weston.log 2>&1
+		weston-launch -- ${WESTON_OPTS} >/tmp/weston.log 2>&1
 
 		# In case of failure, restart after 1s
 		sleep 1


### PR DESCRIPTION
```
Usage: weston-launch [args...] [-- [weston args..]]
  -u, --user      Start session as specified username
  -t, --tty       Start session on alternative tty
  -v, --verbose   Be verbose
  -h, --help      Display this help message
```

Fixes dc28cbf