### PR TITLE
[device-ouya-ouya] Adding device folder, osk-sdl setup

### DIFF
--- a/aports/device/device-ouya-ouya/APKBUILD
+++ b/aports/device/device-ouya-ouya/APKBUILD
@@ -1,0 +1,23 @@
+pkgname=device-ouya-ouya
+pkgver=1
+pkgdesc="Ouya"
+pkgrel=5
+url="https://github.com/postmarketOS"
+arch="noarch"
+license="MIT"
+depends="linux-ouya-ouya mkbootimg"
+makedepends=""
+install=""
+subpackages=""
+source="deviceinfo fb.modes"
+options="!check"
+
+package() {
+	install -D -m644 "$srcdir/deviceinfo" \
+		"$pkgdir/etc/deviceinfo"
+	install -D -m644 "$srcdir"/fb.modes \
+		"$pkgdir/etc/fb.modes"
+}
+
+sha512sums="60c9aa95a15b4c8e48737636eb0f2a2e3a942e0c5ebd88beb3946262fc79b1a5e388cf31e12b253015fc59252234c4082fd63c57a92a1e65fef8eb448ce64e3f  deviceinfo
+bf442fac4dc0594e055ed7a7d8232b5c884e2e77543273e8c4f32b5fe3c199561c86d8a5f665e17406057ca7863fabb93e789fe5e168fcd89d2982e0046232ad  fb.modes"

--- a/aports/device/device-ouya-ouya/deviceinfo
+++ b/aports/device/device-ouya-ouya/deviceinfo
@@ -1,0 +1,30 @@
+# Reference: <https://postmarketos.org/deviceinfo>
+# Please use double quotes only. You can source this file in shell scripts.
+
+deviceinfo_format_version="0"
+deviceinfo_name="Ouya"
+deviceinfo_manufacturer="Ouya"
+deviceinfo_date=""
+deviceinfo_keyboard="false"
+deviceinfo_nonfree="????"
+deviceinfo_dtb=""
+deviceinfo_modules=""
+deviceinfo_modules_initfs=""
+deviceinfo_external_disk="false"
+deviceinfo_external_disk_install="false"
+deviceinfo_flash_methods="fastboot"
+deviceinfo_arch="armhf"
+
+# Splash screen
+deviceinfo_screen_width="800"
+deviceinfo_screen_height="600"
+
+# Fastboot related
+deviceinfo_generate_bootimg="true"
+deviceinfo_flash_offset_kernel="0x00008000"
+deviceinfo_flash_offset_ramdisk="0x01000000"
+deviceinfo_flash_offset_second="0x00f00000"
+deviceinfo_flash_offset_tags="0x00000100"
+deviceinfo_flash_pagesize="131072"
+
+deviceinfo_weston_core_modules="xwayland.so"

--- a/aports/device/device-ouya-ouya/fb.modes
+++ b/aports/device/device-ouya-ouya/fb.modes
@@ -1,0 +1,7 @@
+mode "1920x1080-60"
+	# D: 148.500 MHz, H: 67.500 kHz, V: 60.000 Hz
+	geometry 1920 1080 1920 2160 16
+	timings 6734 148 88 36 4 44 5
+	accel false
+	rgba 8/0,8/8,8/16,8/24
+endmode


### PR DESCRIPTION
postmarketOS/pmbootstrap version is missing the essential device-ouya-ouya folder. Additionally, an fb.modes file has been added that adds support for osk-sdl when it is implemented. Checksums also updated.

I also deleted all the other devices from the device folder for this branch. Is this proper? I feel it would help avoid keeping outdated versions.