### PR TITLE
Install dbus by default

### DIFF
--- a/aports/main/postmarketos-base/APKBUILD
+++ b/aports/main/postmarketos-base/APKBUILD
@@ -1,12 +1,13 @@
 pkgname=postmarketos-base
 pkgver=3
-pkgrel=10
+pkgrel=11
 pkgdesc="Meta package for minimal postmarketOS base"
 url="https://github.com/postmarketOS"
 arch="noarch"
 license="GPL3+"
 depends="
 	alpine-base
+	dbus
 	chrony
 	cryptsetup
 	eudev


### PR DESCRIPTION
Since we are starting it on boot, and wpa_supplicant is being run in 'dbus mode', it makes sense to have it installed by default