### PR TITLE
Close #761: Integrate coveralls.io to show test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,14 @@ addons:
     - debian-sid
     packages:
     - shellcheck
-install: "pip install flake8 pytest-cov"
+install: "pip install flake8 pytest-cov python-coveralls"
 script:
   - test/static_code_analysis.sh
   - yes "" | ./pmbootstrap.py init
   - ./pmbootstrap.py kconfig_check
   - test/testcases_fast.sh
   - test/check_checksums.py
+after_success:
+  - coveralls
 notifications:
   - email: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pmbootstrap
 
-[**Introduction**](https://postmarketos.org/blog/2017/05/26/intro/) | [**Security Warning**](https://ollieparanoid.github.io/post/security-warning/) | [**Supported Devices**](https://wiki.postmarketos.org/wiki/Supported_devices) | [![travis badge](https://api.travis-ci.org/postmarketOS/pmbootstrap.png?branch=master)](https://travis-ci.org/postmarketOS/pmbootstrap)
+[**Introduction**](https://postmarketos.org/blog/2017/05/26/intro/) | [**Security Warning**](https://ollieparanoid.github.io/post/security-warning/) | [**Supported Devices**](https://wiki.postmarketos.org/wiki/Supported_devices) | [![travis badge](https://api.travis-ci.org/postmarketOS/pmbootstrap.png?branch=master)](https://travis-ci.org/postmarketOS/pmbootstrap) | [![Coverage status](https://coveralls.io/repos/github/postmarketOS/pmbootstrap/badge.svg)](https://coveralls.io/github/postmarketOS)
 
 Sophisticated chroot/build/flash tool to develop and install postmarketOS.
 


### PR DESCRIPTION
Whether we do this or not has been discussed here, and no one spoke out against it:
https://github.com/postmarketOS/pmbootstrap/issues/761

Preview of the README.md:
https://github.com/postmarketOS/pmbootstrap/blob/feature/coveralls/README.md

Submitting the coverage is working:
https://coveralls.io/github/postmarketOS/pmbootstrap
