### PR TITLE
Workaround for Qemu aarch64 abuild-tar bug

### DIFF
--- a/aports/main/abuild-aarch64-qemu-workaround/APKBUILD
+++ b/aports/main/abuild-aarch64-qemu-workaround/APKBUILD
@@ -1,0 +1,26 @@
+pkgname=abuild-aarch64-qemu-workaround
+pkgver=3.1.0
+pkgrel=0
+pkgdesc="Patched abuild-tar that works with Qemu"
+url="https://github.com/postmarketOS/pmbootstrap/issues/546"
+arch="aarch64"
+license="GPL2"
+depends=""
+install="$pkgname.post-install"
+options="!check"
+source="abuild-$pkgver.tar.gz::https://github.com/alpinelinux/abuild/archive/v$pkgver.tar.gz write-check-count.patch"
+makedepends="libressl-dev"
+
+builddir="$srcdir/abuild-$pkgver"
+build() {
+	make VERSION="$pkgver-r$pkgrel" abuild-tar
+}
+
+package() {
+	cd "$builddir"
+
+	install -Dm755 abuild-tar "$pkgdir"/usr/bin/abuild-tar-patched
+}
+
+sha512sums="fcdbef96b06a908148d6df41981fca19fe1767274b283efbb3f1adaefc074a4daa7b8eea8d49c533858c464e45b3954f97cd3d0185f0ed7e464244f9802001f5  abuild-3.1.0.tar.gz
+a80c55fe6cb6cc410ca409558c1e1ab8edec9a675031c404cec84c19b4b8460fbbba92db5c1401c0027f8fc0f5be4b82177ec2fad9d734cbc50ca24bfe6e149f  write-check-count.patch"

--- a/aports/main/abuild-aarch64-qemu-workaround/APKBUILD
+++ b/aports/main/abuild-aarch64-qemu-workaround/APKBUILD
@@ -18,7 +18,6 @@ build() {
 
 package() {
 	cd "$builddir"
-
 	install -Dm755 abuild-tar "$pkgdir"/usr/bin/abuild-tar-patched
 }
 

--- a/aports/main/abuild-aarch64-qemu-workaround/abuild-aarch64-qemu-workaround.post-install
+++ b/aports/main/abuild-aarch64-qemu-workaround/abuild-aarch64-qemu-workaround.post-install
@@ -1,0 +1,2 @@
+#!/bin/sh
+ln -svf /usr/bin/abuild-tar-patched /usr/local/bin/abuild-tar

--- a/aports/main/abuild-aarch64-qemu-workaround/write-check-count.patch
+++ b/aports/main/abuild-aarch64-qemu-workaround/write-check-count.patch
@@ -1,0 +1,13 @@
+--- a/abuild-tar.c
++++ b/abuild-tar.c
+@@ -156,7 +156,9 @@ static ssize_t full_write(int fd, const void *buf, size_t count)
+ 		count -= n;
+ 	} while (1);
+ 
+-	if (total == 0 && n < 0)
++	// Workaround for Qemu bug: also check for count:
++	// <https://github.com/postmarketOS/pmbootstrap/issues/546>
++	if (total == 0 && n < 0 && count)
+ 		return -errno;
+ 
+ 	return total;

--- a/pmb/build/__init__.py
+++ b/pmb/build/__init__.py
@@ -23,3 +23,4 @@ from pmb.build.other import copy_to_buildpath, is_necessary, \
     symlink_noarch_packages, find_aport, ccache_stats, index_repo
 from pmb.build.package import package
 from pmb.build.menuconfig import menuconfig
+from pmb.build.qemu_workaround_aarch64 import qemu_workaround_aarch64

--- a/pmb/build/init.py
+++ b/pmb/build/init.py
@@ -20,6 +20,7 @@ import os
 import logging
 import glob
 
+import pmb.build
 import pmb.config
 import pmb.chroot
 import pmb.chroot.apk
@@ -82,6 +83,12 @@ def init(args, suffix="native"):
     # inspect it afterwards for debugging
     pmb.chroot.root(args, ["sed", "-i", "-e", "s/^CLEANUP=.*/CLEANUP=''/",
                            "/etc/abuild.conf"], suffix)
+
+    # Qemu workaround (aarch64 only)
+    arch = pmb.parse.arch.from_chroot_suffix(args, suffix)
+    emulate = pmb.parse.arch.cpu_emulation_required(args, arch)
+    if emulate and arch == "aarch64":
+        pmb.build.qemu_workaround_aarch64(args, suffix)
 
     # Mark the chroot as initialized
     pmb.chroot.root(args, ["touch", marker], suffix)

--- a/pmb/build/package.py
+++ b/pmb/build/package.py
@@ -29,7 +29,8 @@ import pmb.parse
 import pmb.parse.arch
 
 
-def package(args, pkgname, carch, force=False, buildinfo=False, strict=False):
+def package(args, pkgname, carch, force=False, buildinfo=False, strict=False,
+            init_buildenv=True):
     """
     Build a package with Alpine Linux' abuild.
 
@@ -57,7 +58,8 @@ def package(args, pkgname, carch, force=False, buildinfo=False, strict=False):
         return
 
     # Initialize build environment, install/build makedepends
-    pmb.build.init(args, suffix)
+    if init_buildenv:
+        pmb.build.init(args, suffix)
     if len(apkbuild["makedepends"]):
         if strict:
             for makedepend in apkbuild["makedepends"]:

--- a/pmb/build/qemu_workaround_aarch64.py
+++ b/pmb/build/qemu_workaround_aarch64.py
@@ -1,0 +1,42 @@
+"""
+Copyright 2017 Oliver Smith
+
+This file is part of pmbootstrap.
+
+pmbootstrap is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+pmbootstrap is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with pmbootstrap.  If not, see <http://www.gnu.org/licenses/>.
+"""
+import pmb.chroot
+import pmb.chroot.apk_static
+import pmb.config
+import pmb.helpers.repo
+import pmb.helpers.run
+import pmb.parse.arch
+
+
+def qemu_workaround_aarch64(args, suffix="buildroot_aarch64"):
+    """
+    Qemu has a bug in aarch64 emulation, that causes abuild-tar to omit files
+    from the archives it generates in some cases. This workaround copies the
+    abuild-tar binary from the native chroot into the buildroot_aarch64 and
+    installs a wrapper to use it. That way we bypass emulation and it works as
+    expected again.
+
+    https://github.com/postmarketOS/pmbootstrap/issues/546
+    """
+
+    # Build and install abuild-aarch64-qemu-workaround
+    pkgname = "abuild-aarch64-qemu-workaround"
+    pmb.build.package(args, pkgname, "aarch64", True,
+                      init_buildenv=False)
+    pmb.chroot.apk.install(args, [pkgname], suffix, False)

--- a/pmb/build/qemu_workaround_aarch64.py
+++ b/pmb/build/qemu_workaround_aarch64.py
@@ -16,26 +16,18 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with pmbootstrap.  If not, see <http://www.gnu.org/licenses/>.
 """
-import pmb.chroot
-import pmb.chroot.apk_static
-import pmb.config
-import pmb.helpers.repo
-import pmb.helpers.run
-import pmb.parse.arch
+import pmb.build.package
+import pmb.chroot.apk
 
 
 def qemu_workaround_aarch64(args, suffix="buildroot_aarch64"):
     """
     Qemu has a bug in aarch64 emulation, that causes abuild-tar to omit files
-    from the archives it generates in some cases. This workaround copies the
-    abuild-tar binary from the native chroot into the buildroot_aarch64 and
-    installs a wrapper to use it. That way we bypass emulation and it works as
-    expected again.
+    from the archives it generates in some cases. We build a patched abuild-tar,
+    which avoids the bug.
 
     https://github.com/postmarketOS/pmbootstrap/issues/546
     """
-
-    # Build and install abuild-aarch64-qemu-workaround
     pkgname = "abuild-aarch64-qemu-workaround"
     pmb.build.package(args, pkgname, "aarch64", True,
                       init_buildenv=False)


### PR DESCRIPTION
Qemu has a bug in aarch64 emulation, that causes `abuild-tar` to omit files from the archives it generates in some cases (#546). This workaround ~~copies the `abuild-tar` binary from the native chroot into the buildroot_aarch64 and installs a wrapper to use it. That way we bypass emulation and it works as expected again.~~ builds a patched `abuild-tar`, which avoids the bug.

