### PR TITLE
Allow configuring ccache size and skipping build options in init

### DIFF
--- a/pmb/build/__init__.py
+++ b/pmb/build/__init__.py
@@ -20,7 +20,7 @@ along with pmbootstrap.  If not, see <http://www.gnu.org/licenses/>.
 from pmb.build.init import init
 from pmb.build.checksum import checksum
 from pmb.build.other import copy_to_buildpath, is_necessary, \
-    symlink_noarch_packages, find_aport, ccache_stats, index_repo
+    symlink_noarch_packages, find_aport, index_repo
 from pmb.build.package import package
 from pmb.build.menuconfig import menuconfig
 from pmb.build.qemu_workaround_aarch64 import qemu_workaround_aarch64

--- a/pmb/build/package.py
+++ b/pmb/build/package.py
@@ -83,8 +83,9 @@ def package(args, pkgname, carch, force=False, buildinfo=False, strict=False,
     if not force and not pmb.build.is_necessary(args, carch, apkbuild):
         return
 
-    # Configure abuild.conf
+    # Configure abuild and ccache
     pmb.build.other.configure_abuild(args, suffix)
+    pmb.build.other.configure_ccache(args)
 
     # Generate output name, log build message
     output = (carch_buildenv + "/" + apkbuild["pkgname"] + "-" +

--- a/pmb/config/__init__.py
+++ b/pmb/config/__init__.py
@@ -45,8 +45,9 @@ apk_tools_static_min_version = "2.7.2-r0"
 work_version = "1"
 
 # Only save keys to the config file, which we ask for in 'pmbootstrap init'.
-config_keys = ["device", "extra_packages", "jobs", "timestamp_based_rebuild",
-               "work", "qemu_mesa_driver", "ui", "user", "keymap", "timezone"]
+config_keys = ["ccache_size", "device", "extra_packages", "jobs", "keymap",
+               "qemu_mesa_driver", "timestamp_based_rebuild", "timezone"
+               "ui", "user", "work"]
 
 # Config file/commandline default values
 # $WORK gets replaced with the actual value for args.work (which may be
@@ -54,29 +55,29 @@ config_keys = ["device", "extra_packages", "jobs", "timestamp_based_rebuild",
 defaults = {
     "alpine_version": "edge",  # alternatively: latest-stable
     "aports": os.path.normpath(pmb_src + "/aports"),
-    "config": os.path.expanduser("~") + "/.config/pmbootstrap.cfg",
-    "device": "samsung-i9100",
-    "extra_packages": "none",
-    "jobs": str(multiprocessing.cpu_count() + 1),
-    "timestamp_based_rebuild": True,
-    "log": "$WORK/log.txt",
-    "mirror_alpine": "http://dl-cdn.alpinelinux.org/alpine/",
-    "mirror_postmarketos": "http://postmarketos.brixit.nl",
-    "work": os.path.expanduser("~") + "/.local/var/pmbootstrap",
-    "port_distccd": "33632",
-    "qemu_mesa_driver": "dri-virtio",
-    "ui": "weston",
-    "user": "user",
-    "keymap": "",
-    "timezone": "GMT",
-
+    "ccache_size": "5G",
     # aes-xts-plain64 would be better, but this is not supported on LineageOS
     # kernel configs
     "cipher": "aes-cbc-plain64",
+    "config": os.path.expanduser("~") + "/.config/pmbootstrap.cfg",
+    "device": "samsung-i9100",
+    "extra_packages": "none",
     # A higher value is typically desired, but this can lead to VERY long open
     # times on slower devices due to host systems being MUCH faster than the
     # target device: <https://github.com/postmarketOS/pmbootstrap/issues/429>
-    "iter_time": "200"
+    "iter_time": "200",
+    "jobs": str(multiprocessing.cpu_count() + 1),
+    "keymap": "",
+    "log": "$WORK/log.txt",
+    "mirror_alpine": "http://dl-cdn.alpinelinux.org/alpine/",
+    "mirror_postmarketos": "http://postmarketos.brixit.nl",
+    "port_distccd": "33632",
+    "qemu_mesa_driver": "dri-virtio",
+    "timestamp_based_rebuild": True,
+    "timezone": "GMT",
+    "ui": "weston",
+    "user": "user",
+    "work": os.path.expanduser("~") + "/.local/var/pmbootstrap",
 }
 
 #

--- a/pmb/config/init.py
+++ b/pmb/config/init.py
@@ -118,7 +118,8 @@ def ask_for_timezone(args):
             if pmb.helpers.cli.confirm(args, "Use this timezone instead of GMT?",
                                        default="y"):
                 return tz
-    logging.info("WARNING: Unable to determine timezone configuration on host, using GMT.")
+    logging.info("WARNING: Unable to determine timezone configuration on host,"
+                 " using GMT.")
     return "GMT"
 
 
@@ -160,6 +161,44 @@ def ask_for_qemu_mesa_driver(args):
                       " it, see qemu_mesa_drivers in pmb/config/__init__.py.")
 
 
+def ask_for_build_options(args, cfg):
+    # Allow to skip build options
+    ts_rebuild = "True" if args.timestamp_based_rebuild else "False"
+    logging.info("Build options: Parallel jobs: " + args.jobs +
+                 ", ccache size: " + args.ccache_size +
+                 ", timestamp based rebuilds: " + ts_rebuild)
+
+    if not pmb.helpers.cli.confirm(args, "Change?",
+                                   default=False):
+        return
+
+    # Parallel job count
+    logging.info("How many jobs should run parallel on this machine, when"
+                 " compiling?")
+    answer = pmb.helpers.cli.ask(args, "Jobs", None, args.jobs,
+                                 validation_regex="[1-9][0-9]*")
+    cfg["pmbootstrap"]["jobs"] = answer
+
+    # Ccache size
+    logging.info("We use ccache to speed up building the same code multiple"
+                 " times. How much space should the ccache folder take up?"
+                 " (After init is through, you can check the current usage"
+                 " with 'pmbootstrap stats'.)")
+    logging.info("0: infinite")
+    regex = "0|[0-9]+(k|M|G|T|Ki|Mi|Gi|Ti)"
+    answer = pmb.helpers.cli.ask(args, "Ccache size", None, args.ccache_size,
+                                 lowercase_answer=False, validation_regex=regex)
+    cfg["pmbootstrap"]["ccache_size"] = answer
+
+    # Timestamp based rebuilds
+    logging.info("Rebuild packages, when the last modified timestamp changed,"
+                 " even if the version did not change? This makes pmbootstrap"
+                 " behave more like 'make'.")
+    answer = pmb.helpers.cli.confirm(args, "Timestamp based rebuilds",
+                                     default=args.timestamp_based_rebuild)
+    cfg["pmbootstrap"]["timestamp_based_rebuild"] = str(answer)
+
+
 def frontend(args):
     cfg = pmb.config.load(args)
 
@@ -172,7 +211,8 @@ def frontend(args):
 
     # Device keymap
     if device_exists:
-        cfg["pmbootstrap"]["keymap"] = ask_for_keymaps(args, device=cfg["pmbootstrap"]["device"])
+        cfg["pmbootstrap"]["keymap"] = ask_for_keymaps(
+            args, device=cfg["pmbootstrap"]["device"])
 
     # Username
     cfg["pmbootstrap"]["user"] = pmb.helpers.cli.ask(args, "Username", None,
@@ -182,19 +222,8 @@ def frontend(args):
     cfg["pmbootstrap"]["ui"] = ask_for_ui(args)
     cfg["pmbootstrap"]["work"] = ask_for_work_path(args)
 
-    # Parallel job count
-    logging.info("How many jobs should run parallel on this machine, when"
-                 " compiling?")
-    cfg["pmbootstrap"]["jobs"] = pmb.helpers.cli.ask(args, "Jobs",
-                                                     None, args.jobs, validation_regex="[1-9][0-9]*")
-
-    # Timestamp based rebuilds
-    logging.info("Rebuild packages, when the last modified timestamp changed,"
-                 " even if the version did not change? This makes pmbootstrap"
-                 " behave more like 'make'.")
-    answer = pmb.helpers.cli.confirm(args, "Timestamp based rebuilds",
-                                     default=args.timestamp_based_rebuild)
-    cfg["pmbootstrap"]["timestamp_based_rebuild"] = str(answer)
+    # Various build options
+    ask_for_build_options(args, cfg)
 
     # Extra packages to be installed to rootfs
     logging.info("Additional packages that will be installed to rootfs."
@@ -215,7 +244,8 @@ def frontend(args):
     if (device_exists and
             len(glob.glob(args.work + "/chroot_*")) and
             pmb.helpers.cli.confirm(args, "Zap existing chroots to apply configuration?", default=True)):
-        setattr(args, "deviceinfo", pmb.parse.deviceinfo(args, device=cfg["pmbootstrap"]["device"]))
+        setattr(args, "deviceinfo", pmb.parse.deviceinfo(
+            args, device=cfg["pmbootstrap"]["device"]))
         # Do not zap any existing packages or cache_http directories
         pmb.chroot.zap(args, confirm=False)
 

--- a/pmb/helpers/frontend.py
+++ b/pmb/helpers/frontend.py
@@ -208,7 +208,8 @@ def shutdown(args):
 
 
 def stats(args):
-    pmb.build.ccache_stats(args, args.arch)
+    pmb.chroot.apk.install(args, ["ccache"])
+    pmb.chroot.user(args, ["ccache", "-s"], log=False)
 
 
 def log(args):

--- a/pmb/parse/arguments.py
+++ b/pmb/parse/arguments.py
@@ -206,8 +206,7 @@ def arguments():
                      " downloaded files cache")
 
     # Action: stats
-    stats = sub.add_parser("stats", help="show ccache stats")
-    stats.add_argument("--arch")
+    sub.add_parser("stats", help="show ccache stats")
 
     # Action: build_init / chroot
     build_init = sub.add_parser("build_init", help="initialize build"


### PR DESCRIPTION
This is very useful for the binary repository, because I'm almost hitting the default cache size of 5 GB from ccache already (4.7 or so is what I have right now) and I have not even started with compiling KDE. With this PR, one can set it as big/as small, as desired.

### Output
Here's how `pmbootstrap init` looks like with this PR. First the usual stuff...
```
[18:15:49] Target device (either an existing one, or a new one for porting).
[18:15:49] Available (35): amazon-thor, asus-flo, asus-grouper, ...
[18:15:49] Device [samsung-i9100]:
[18:15:49] Username [user]:
[18:15:49] Available user interfaces (3):
[18:15:49] * none: No graphical environment
[18:15:49] * hildon: (X11) Lightweight GTK+2 UI (optimized for single-touch touchscreens)
[18:15:49] * weston: (Wayland) Reference compositor (demo, not a phone interface)
[18:15:49] * xfce4: (X11) Lightweight GTK+2 desktop (stylus recommended)
[18:15:49] User interface [weston]:
[18:15:50] Location of the 'work' path. Multiple chroots (native, device arch, device rootfs) will be created in there.
[18:15:50] Work path [/home/user/.local/var/pmbootstrap]:
```

Then the grouped build options:
```
[18:15:51] Build options: Parallel jobs: 3, ccache size: 5G, timestamp based rebuilds: False
[18:15:51] Change? (y/n) [n]: y
```

When answering with `y`:
```
[18:15:57] How many jobs should run parallel on this machine, when compiling?
[18:15:57] Jobs [3]:
[18:15:58] We use ccache to speed up building the same code multiple times. How much space should the ccache folder take up? (After init is through, you can check the current usage with 'pmbootstrap stats'.)
[18:15:58] 0: infinite
[18:15:58] Ccache size [5G]:
[18:16:00] Rebuild packages, when the last modified timestamp changed, even if the version did not change? This makes pmbootstrap behave more like 'make'.
[18:16:00] Timestamp based rebuilds (y/n) [y]:
```

When finished with the above or pressed `n` there, then you'll continue as usually:
```
[18:16:03] Additional packages that will be installed to rootfs. Specify them in a comma separated list (e.g.: vim,file) or "none"
[18:16:03] Extra packages [none]:
...
```

### Detailed changes
* allow configuring the ccache size
* allow to skip changing build related options in `pmbootstrap init`
  (so we stop making the list of questions longer and longer)
* sort config keys alphabetically
* remove the arch parameter from `pmbootstrap stats` (which shows
  the ccache stats). The reason is, that whenever you are
  cross-compiling with distcc, the ccache layer is used in the
  native chroot (so the ccache code runs without emulation and is
  therefore faster). That means, it makes little sense to choose
  another architecture to get the statistics, and removing it
  makes the code a bit simpler.
* move ccache_stats out of `pmb/build/__init__.py again`, directly
  putting the two lines of logic into `frontend.py` makes it simpler
* fix: make sure, that ccache is installed when running
  `pmbootstrap stats`