### PR TITLE
pmbootstrap: fix listing of mounts if the file was deleted

### DIFF
--- a/pmb/helpers/mount.py
+++ b/pmb/helpers/mount.py
@@ -94,7 +94,11 @@ def umount_all_list(prefix, source="/proc/mounts"):
                 raise RuntimeError("Failed to parse line in " + source + ": " +
                                    line)
             if words[1].startswith(prefix):
-                ret.append(words[1])
+                p = words[1]
+                deletedStr = r"\040(deleted)"
+                if p.endswith(deletedStr):
+                    p = p[:-len(deletedStr)]
+                ret.append(p)
     ret.sort(reverse=True)
     return ret
 

--- a/pmb/helpers/mount.py
+++ b/pmb/helpers/mount.py
@@ -93,12 +93,13 @@ def umount_all_list(prefix, source="/proc/mounts"):
             if len(words) < 2:
                 raise RuntimeError("Failed to parse line in " + source + ": " +
                                    line)
-            if words[1].startswith(prefix):
-                p = words[1]
-                deletedStr = r"\040(deleted)"
-                if p.endswith(deletedStr):
-                    p = p[:-len(deletedStr)]
-                ret.append(p)
+            mountpoint = words[1]
+            if mountpoint.startswith(prefix):
+                # Remove "\040(deleted)" suffix (#545)
+                deleted_str = r"\040(deleted)"
+                if mountpoint.endswith(deleted_str):
+                    mountpoint = mountpoint[:-len(deleted_str)]
+                ret.append(mountpoint)
     ret.sort(reverse=True)
     return ret
 

--- a/test/test_mount.py
+++ b/test/test_mount.py
@@ -33,6 +33,7 @@ def test_umount_all_list(tmpdir):
         handle.write("source /test/home/pmos/packages\n")
         handle.write("source /test\n")
         handle.write("source /test/proc\n")
+        handle.write("source /test/dev/loop0p2\\040(deleted)\n")
 
     ret = pmb.helpers.mount.umount_all_list("/no/match", fake_mounts)
     assert ret == []
@@ -42,4 +43,4 @@ def test_umount_all_list(tmpdir):
 
     ret = pmb.helpers.mount.umount_all_list("/test", fake_mounts)
     assert ret == ["/test/var/cache", "/test/proc", "/test/home/pmos/packages",
-                   "/test"]
+                   "/test/dev/loop0p2", "/test"]


### PR DESCRIPTION
On my system, /proc/mounts sometimes contains a line like

```
udev /media/zhuowei/redhd/pmbootstrap/chroot_native/dev/loop0p2\040(deleted)
 devtmpfs rw,relatime,size=1959476k,nr_inodes=489869,mode=755 0 0
```

The "\040(deleted)" text confuses `pmbootstrap shutdown`. Remove the suffix
if we find it in a /proc/mounts entry.

This fixes #545.