### PR TITLE
[hildon-ui] Rotate display and touchscreen coordinates

### DIFF
--- a/aports/main/postmarketos-ui-hildon/APKBUILD
+++ b/aports/main/postmarketos-ui-hildon/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=postmarketos-ui-hildon
 pkgver=1
-pkgrel=3
+pkgrel=4
 pkgdesc="(X11) Lightweight GTK+2 UI (optimized for single-touch touchscreens)"
 url="https://github.com/postmarketOS"
 arch="noarch"
@@ -11,11 +11,16 @@ depends="
 	hildon-theme-alpha
 	mesa
 	xorg-server
+	xinput
 "
 makedepends=""
 install="$pkgname.post-install"
 subpackages=""
-source="start_hildon.sh xinitrc_hildon.sh $install"
+source="
+	start_hildon.sh
+	xinitrc_hildon.sh
+	x11-fbdev-rotate.conf
+"
 options="!check"
 
 package() {
@@ -28,7 +33,10 @@ package() {
 		"$pkgdir"/etc/profile.d/start_hildon.sh
 	install -D -m644 "$srcdir"/xinitrc_hildon.sh \
 		"$pkgdir"/etc/postmarketos-ui/xinitrc_hildon.sh
+	install -D -m644 "$srcdir"/x11-fbdev-rotate.conf \
+		"$pkgdir"/etc/X11/xorg.conf.d/00-fbdev-rotate.conf
 }
+
 sha512sums="6c446fd2c0c50b10bf3bd4da93520b975f3632dab24c34eb33f22af7fdd2d96b8d7b605a4aee0c8e2544f56b7fd2dfc0ad39dc57b11cb2eb8c952f823d1b2987  start_hildon.sh
-5ef5710bee7bde99e1f240eb8873239c452b55c6dc943930e181d091835824094cf56bf29ae1b34d792ba0ce27f76e30ea69f3c125dda3bf286eaaaba8c8e6ae  xinitrc_hildon.sh
-64007cebcfbb9d8cdc4db7f889722509e1090af0712802300611fb805e00e1de474e4e6b538d0d99be05ca25f983e94aab57e04b4cc8282ba0ae44609d1a7366  postmarketos-ui-hildon.post-install"
+cd38906c096660ef976a836faa7f3706da1f52adc93911c6c9ef6a0ab2f1d594f2a696fea5c34bcad16ef899e196827d1b5b89c8691a3c395ebb31977d7aefd2  xinitrc_hildon.sh
+7b05ac71c2255fc0768d1b93761166ab749c1499d43845482cbbb5792b8482a55e3e6ededf8cc99a254c2c1ecceae07faaf4a025154b4a95060d5c46a203e1c6  x11-fbdev-rotate.conf"

--- a/aports/main/postmarketos-ui-hildon/x11-fbdev-rotate.conf
+++ b/aports/main/postmarketos-ui-hildon/x11-fbdev-rotate.conf
@@ -1,0 +1,5 @@
+Section "Device"
+  Identifier "LCD"
+  Driver "fbdev"
+  Option "Rotate" "CW"
+EndSection

--- a/aports/main/postmarketos-ui-hildon/xinitrc_hildon.sh
+++ b/aports/main/postmarketos-ui-hildon/xinitrc_hildon.sh
@@ -11,6 +11,14 @@ done
 # Start dbus and export its environment variables
 eval "$(dbus-launch --sh-syntax --exit-with-session)"
 
+. /etc/deviceinfo
+if [ ! -z "$deviceinfo_dev_touchscreen" ]; then
+	# walk through all the attributes of the parent devices and reverse the
+	# output to find and extract the name attribute of the top parent device
+	touch_name=$(udevadm info -a -n "${deviceinfo_dev_touchscreen}" | tac | grep -m1 "ATTRS{name}" | cut -d '"' -f2)
+	xinput set-prop "$touch_name" "Coordinate Transformation Matrix" 0 1 0 -1 0 1 0 0 1
+fi
+
 # Start X11 with Hildon
 export LC_MESSAGES=en_US.UTF-8
 exec hildon-desktop


### PR DESCRIPTION
This adds an X11 configuration file (`x11-fbdev-rotate.conf`) to rotate the display by 90° degrees clockwise.

In order to rotate the touchscreen, in the `xinitrc_hildon.sh` script, it gets the `deviceinfo_dev_touchscreen` variable from the `/etc/deviceinfo` file and perform a query with `udevadm` in order to find out the corresponding name of the touchscreen device.
With the touchscreen device name it calls `xinit` to set the `Coordinate Transformation Matrix` in order to rotate the touch.
This part works but is a bit fragile and needs to be tested on various devices.
An alternative solution would be to find a way to set the coordinate transformation matrix using the `/dev/input/eventX` directly (with udev rule is possible).

Closes #819