### PR TITLE
Fix for qtwebengine not linking on armhf (towards #1008)

### DIFF
--- a/aports/luna/luna-app-browser/APKBUILD
+++ b/aports/luna/luna-app-browser/APKBUILD
@@ -3,8 +3,8 @@ pkgver=8.0.0_git20171004
 pkgrel=2
 _commit=7e7a8f477039483c3a05f53a2eb980884560dc32
 pkgdesc="LuneOS web browser"
-# Disabled for armhf, aarch64 (see #1008)
-arch="x86_64"
+# Disabled for aarch64 (see #1008)
+arch="x86_64 armhf"
 url="http://webos-ports.org"
 license="GPL-3.0+"
 depends="qt5-qtquickcontrols2 qt5-qtquickcontrols qt5-qtwebengine"

--- a/aports/luna/luna-core-apps/APKBUILD
+++ b/aports/luna/luna-core-apps/APKBUILD
@@ -3,8 +3,8 @@ pkgver=1.0.5_git20170804
 pkgrel=1
 _commit=da721460474039a2412dc6f47a2e8464e38fc6fd
 pkgdesc="The new webOS UI of the webOS ports project."
-# Disabled for armhf, aarch64 (see #1008)
-arch="x86_64"
+# Disabled for aarch64 (see #1008)
+arch="x86_64 armhf"
 url="http://webos-ports.org"
 license="GPL-3.0+"
 depends="luna-webappmanager enyo luna-app-services"

--- a/aports/luna/luna-qml-launcher/APKBUILD
+++ b/aports/luna/luna-qml-launcher/APKBUILD
@@ -3,8 +3,8 @@ pkgver=5.0.0_git20171102
 pkgrel=0
 _commit=aacef1d20c9c3656db4ecff949f23231120f8449
 pkgdesc="Launcher for Lune OS based QML applications"
-# Disabled for armhf, aarch64 (see #1008)
-arch="x86_64"
+# Disabled for aarch64 (see #1008)
+arch="x86_64 armhf"
 url="https://github.com/webOS-ports/luna-qml-launcher"
 license="GPL-3.0+"
 depends="qt5-qtwebengine qt5-qtquickcontrols2 luna-service2 luna-sysmgr-common glib libwebos-application json-c"

--- a/aports/luna/luna-webappmanager/APKBUILD
+++ b/aports/luna/luna-webappmanager/APKBUILD
@@ -3,8 +3,8 @@ pkgver=8.0.0_git20170908
 pkgrel=2
 _commit=89e9c3e2437c21dcdaced17c7b5df5cc41efd051
 pkgdesc="Component responsible for application management in LuneOS"
-# Disabled for armhf, aarch64 (see #1008)
-arch="x86_64"
+# Disabled for aarch64 (see #1008)
+arch="x86_64 armhf"
 url="http://webos-ports.org"
 license="GPL-3.0+"
 depends="glib luna-service2 libpbnjson luna-sysmgr-common luna-prefs qt5-qtbase qt5-qtquickcontrols2 qt5-qtdeclarative qt5-qtwebengine qt5-qtwebchannel libconnman-qt"

--- a/aports/main/qt5-qtwebengine/APKBUILD
+++ b/aports/main/qt5-qtwebengine/APKBUILD
@@ -1,13 +1,13 @@
 pkgname=qt5-qtwebengine
 pkgver=5.9.3
 pkgrel=0
-# Disabled for armhf, aarch64 (see #1008)
-arch="x86_64"
+# Disabled for aarch64 (see #1008)
+arch="x86_64 armhf"
 url='http://qt-project.org/'
 license="GPL3 LGPL3 FDL custom"
 pkgdesc='Provides communication between JS/HTML and Qt apps'
 depends="qt5-qtbase qt5-qtquickcontrols2 python2 fontconfig dbus-x11 libcap libdrm libxcomposite libxcursor libxi libxrandr libxscrnsaver libxtst alsa-lib ffmpeg libwebp opus icu-libs libevent libexecinfo qt5-qtwebchannel libjpeg-turbo libintl gettext dbus libpbnjson luna-service2"
-makedepends="qt5-qtbase-dev qt5-qtquickcontrols2-dev python2-dev bison flex gperf fontconfig-dev mesa-dev libcap-dev libdrm-dev libxcomposite-dev libxcursor-dev libxi-dev libxrandr-dev libxscrnsaver-dev libxtst-dev alsa-lib-dev ffmpeg-dev ffmpeg-libs jsoncpp-dev ninja libwebp-dev opus-dev icu-dev libevent-dev bsd-compat-headers libexecinfo-dev git qt5-qtwebchannel-dev libjpeg-turbo-dev gzip libintl gettext-dev yasm dbus-dev libpbnjson-dev luna-service2-dev"
+makedepends="qt5-qtbase-dev qt5-qtquickcontrols2-dev python2-dev bison flex gperf fontconfig-dev mesa-dev libcap-dev libdrm-dev libxcomposite-dev libxcursor-dev libxi-dev libxrandr-dev libxscrnsaver-dev libxtst-dev alsa-lib-dev ffmpeg-dev ffmpeg-libs jsoncpp-dev ninja libwebp-dev opus-dev icu-dev libevent-dev bsd-compat-headers libexecinfo-dev git qt5-qtwebchannel-dev libjpeg-turbo-dev gzip libintl gettext-dev yasm dbus-dev libpbnjson-dev luna-service2-dev binutils-gold"
 builddir="$srcdir/${pkgname/qt5-/}-opensource-src-$pkgver"
 source="http://download.qt.io/official_releases/qt/${pkgver%.*}/${pkgver}/submodules/${pkgname/qt5-/}-opensource-src-$pkgver.tar.xz
 patches-musl/0001-chromium-Change-false-to-FALSE-and-1-to-TRUE-FIX-qtw.patch
@@ -77,7 +77,7 @@ build() {
 	cd $srcdir/build
 
 	export QT_CONFIG=system-ffmpeg
-	qmake-qt5 WEBENGINE_CONFIG+=use_system_ffmpeg "$srcdir"/${pkgname/qt5-/}-opensource-src-$pkgver 
+	qmake-qt5 CONFIG+="use_gold_linker" WEBENGINE_CONFIG+="use_system_ffmpeg use_gold_linker" "$srcdir"/${pkgname/qt5-/}-opensource-src-$pkgver 
 	make
 }
 


### PR DESCRIPTION
Using the `gold` linker uses much less memory, so linking succeeds.

Also re-enable armhf arch for relevant Luna packages.