### PR TITLE
semc-anzu: correct pixman type to match framebuffer

### DIFF
--- a/aports/device/device-semc-anzu/APKBUILD
+++ b/aports/device/device-semc-anzu/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=device-semc-anzu
 pkgdesc="Xperia Arc"
 pkgver=1
-pkgrel=0
+pkgrel=1
 url="https://postmarketos.org"
 license="MIT"
 arch="noarch"

--- a/aports/device/device-semc-anzu/deviceinfo
+++ b/aports/device/device-semc-anzu/deviceinfo
@@ -19,7 +19,7 @@ deviceinfo_dev_touchscreen="/dev/input/event2"
 deviceinfo_dev_touchscreen_calibration=""
 deviceinfo_dev_keyboard=""
 deviceinfo_msm_refresher="true"
-deviceinfo_weston_pixman_type="2"
+deviceinfo_weston_pixman_type="3"
 
 # Bootloader related
 deviceinfo_flash_method="fastboot"


### PR DESCRIPTION
Apologies for the omission.

If #1088 requires any additional changes in device-semc-anzu, it's probably a good idea to delay this pull request until said changes are done.