### PR TITLE
Improved pmbootstrap init

### DIFF
--- a/pmb/chroot/apk.py
+++ b/pmb/chroot/apk.py
@@ -226,15 +226,14 @@ def install(args, packages, suffix="native", build=True):
                     suffix)
 
 
-def upgrade(args, suffix="native", update_index=True):
+def upgrade(args, suffix="native"):
     """
     Upgrade all packages installed in a chroot
     """
     # Prepare apk and update index
     check_min_version(args, suffix)
     pmb.chroot.init(args, suffix)
-    if update_index:
-        pmb.chroot.root(args, ["apk", "update"], suffix)
+    pmb.helpers.repo.update(args)
 
     # Rebuild and upgrade out-of-date packages
     packages = installed(args, suffix).keys()

--- a/pmb/chroot/apk_static.py
+++ b/pmb/chroot/apk_static.py
@@ -158,21 +158,28 @@ def init(args):
     """
     Download, verify, extract $WORK/apk.static.
     """
-    apkindex = download(args, "APKINDEX.tar.gz")
+    # Get the APKINDEX
+    pmb.helpers.repo.update(args)
+    url = args.mirror_alpine + args.alpine_version + "/main"
+    apkindex = (args.work + "/cache_apk_" + args.arch_native + "/APKINDEX." +
+                pmb.helpers.repo.hash(url) + ".tar.gz")
+
+    # Extract and verify the apk-tools-static version
     index_data = pmb.parse.apkindex.read(args, "apk-tools-static", apkindex)
     version = index_data["version"]
     version_min = pmb.config.apk_tools_static_min_version
     apk_name = "apk-tools-static-" + version + ".apk"
     if pmb.parse.version.compare(version, version_min) == -1:
-        raise RuntimeError("You have an outdated version of apk-tools-static"
-                           " (your version: " + version +
-                           ", expected at least:"
-                           " " + version_min + "). Delete your http cache and zap"
-                           " all chroots, then try again: 'pmbootstrap zap -hc'")
+        raise RuntimeError("Your APKINDEX has an outdated version of"
+                           " apk-tools-static (your version: " + version +
+                           ", expected at least:" + version_min + "). Please" +
+                           " run 'pmbootstrap update'.")
+
+    # Download, extract, verify apk-tools-static
     apk_static = download(args, apk_name)
     extract(args, version, apk_static)
 
 
-def run(args, parameters, check):
+def run(args, parameters, check=True):
     pmb.helpers.run.root(
         args, [args.work + "/apk.static"] + parameters, check=check)

--- a/pmb/chroot/init.py
+++ b/pmb/chroot/init.py
@@ -70,20 +70,21 @@ def create_device_nodes(args, suffix):
 
         # Verify major and minor numbers of created nodes
         for dev in pmb.config.chroot_device_nodes:
-            stat_result = os.stat(chroot + "/dev/" + str(dev[4]))
+            path = chroot + "/dev/" + str(dev[4])
+            stat_result = os.stat(path)
             rdev = stat_result.st_rdev
-            assert os.major(rdev) == dev[2]
-            assert os.minor(rdev) == dev[3]
+            assert os.major(rdev) == dev[2], "Wrong major in " + path
+            assert os.minor(rdev) == dev[3], "Wrong minor in " + path
 
         # Verify /dev/zero reading and writing
         path = chroot + "/dev/zero"
-        logging.debug("Test device node: " + path)
         with open(path, "r+b", 0) as handle:
-            assert handle.write(bytes([0xff]))
-            assert handle.read(1) == bytes([0x00])
+            assert handle.write(bytes([0xff])), "Write failed for " + path
+            assert handle.read(1) == bytes([0x00]), "Read failed for " + path
 
     # On failure: Show filesystem-related error
     except Exception as e:
+        logging.info(str(e) + "!")
         raise RuntimeError(error)
 
 

--- a/pmb/chroot/init.py
+++ b/pmb/chroot/init.py
@@ -79,6 +79,7 @@ def create_device_nodes(args, suffix):
     except Exception as e:
             raise RuntimeError(error)
 
+
 def init(args, suffix="native"):
     # When already initialized: just prepare the chroot
     chroot = args.work + "/chroot_" + suffix

--- a/pmb/parse/arch.py
+++ b/pmb/parse/arch.py
@@ -42,7 +42,7 @@ def from_chroot_suffix(args, suffix):
     if suffix == "rootfs_" + args.device:
         return args.deviceinfo["arch"]
     if suffix.startswith("buildroot_"):
-        return suffix.split("_", 2)[1]
+        return "_".join(suffix.split("_", 2)[1:])
 
     raise ValueError("Invalid chroot suffix: " + suffix +
                      " (wrong device chosen in 'init' step?)")

--- a/pmb/parse/arch.py
+++ b/pmb/parse/arch.py
@@ -42,7 +42,7 @@ def from_chroot_suffix(args, suffix):
     if suffix == "rootfs_" + args.device:
         return args.deviceinfo["arch"]
     if suffix.startswith("buildroot_"):
-        return "_".join(suffix.split("_", 2)[1:])
+        return suffix.split("_", 1)[1]
 
     raise ValueError("Invalid chroot suffix: " + suffix +
                      " (wrong device chosen in 'init' step?)")


### PR DESCRIPTION
* Check if it's possible to create and read from a device node directly when initializing a chroot (closes #472)
* Copy the Qemu binary into the forign-arch chroots before initializing them, so the post-install scripts directly work during the chroot setup and we don't need to call `apk fix` afterwards
* Use `pmb.helpers.repo.update()`, which only updates the `APKINDEX` files if they are older than 4 hours, instead of using `apk`'s repo update function which always downloads the `APKINDEX` files
  *  Chroot initialization
  *  Getting the initial `APKINDEX` to download `apk-tools-static`
  * Updating the `APKINDEX` at the start of `pmbootstrap install`
* Fixed a bug in `from_chroot_suffix`: the `buildroot_x86_64` has architecture `x86_64`, not `x86`. This was randomly discovered because Travis didn't have the APKINDEX files in `buildroot_x86_64`, because they didn't get mounted right.

All in all this PR will make the workflow a bit faster and `pmbootstrap` will produce less traffic.