### PR TITLE
Luna: Fix startup, add default background image

### DIFF
--- a/aports/luna/luna-init/APKBUILD
+++ b/aports/luna/luna-init/APKBUILD
@@ -1,24 +1,16 @@
 pkgname=luna-init
 pkgver=5.0.0_git20171117
-pkgrel=2
+pkgrel=1
 _commit=5fff640fb0b9f3e973c13d1620889b2da4c11766
-_artwork_commit="2cad2af027fbec6aef0d1f16226a41ccf427f44e"
 pkgdesc="Initialization and font setup files used by luna-sysmgr."
 arch="all"
 url="http://webos-ports.org"
 license="GPL-3.0+"
 depends=""
-makedepends="cmake-modules-webos python2 py2-tz imagemagick"
-source="$pkgname-$_commit.tar.gz::https://github.com/webOS-ports/luna-init/archive/$_commit.tar.gz
-postmarketos-artwork-$_artwork_commit.tar.gz::https://github.com/postmarketOS/artwork/archive/${_artwork_commit}.tar.gz"
+makedepends="cmake-modules-webos python2 py2-tz"
+source="$pkgname-$_commit.tar.gz::https://github.com/webOS-ports/luna-init/archive/$_commit.tar.gz"
 options="!check"
 builddir="$srcdir/$pkgname-$_commit"
-
-prepare() {
-	default_prepare
-	cd "$srcdir"
-	tar xzf postmarketos-artwork-$_artwork_commit.tar.gz
-}
 
 build() {
 	mkdir -p "$srcdir"/build
@@ -28,10 +20,6 @@ build() {
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DWEBOS_INSTALL_ROOT=/
 	make
-
-	# Convert a wallpaper to jpg. Unfortunately required by luna-next-cardshell.
-	# This is done here to remain consistant with the upstream luna-init package which packages the default background image for LuneOS.
-	convert "$srcdir"/artwork-"$_artwork_commit"/wallpapers/logo/postmarketos.png "$srcdir"/build/postmarketos.jpg
 }
 
 package() {
@@ -46,12 +34,6 @@ package() {
 	install -v -m 644 "$builddir"/files/conf/default-dock-positions.json "$pkgdir"/etc/palm
 	install -v -m 644 "$builddir"/files/conf/default-launcher-page-layout.json "$pkgdir"/etc/palm
 	install -v -m 644 "$builddir"/files/conf/locale.txt "$pkgdir"/etc/palm
-	
-	# Install a default background image.
-
-	install -d "$pkgdir"/media/internal/wallpapers
-	install -v -m 644 "$srcdir"/build/postmarketos.jpg "$pkgdir"/media/internal/wallpapers/LuneOS.jpg
 
 }
-sha512sums="9278b53e8358230e0979d314958a02ada6d68a68b97e253d81ffc5132901cf7aa033c8d908530cbf36c422a161a3f80cc70f1ddb3e0e4b3fae86183c39d10b95  luna-init-5fff640fb0b9f3e973c13d1620889b2da4c11766.tar.gz
-b86010a33332fe6c3d983e22c982e8edf232bd66d85a4999ecbeb793e24a17c98cb5a51fe476b7a484f79b76908f32d1eae066b7c99cd142f5a810ac46ade163  postmarketos-artwork-2cad2af027fbec6aef0d1f16226a41ccf427f44e.tar.gz"
+sha512sums="9278b53e8358230e0979d314958a02ada6d68a68b97e253d81ffc5132901cf7aa033c8d908530cbf36c422a161a3f80cc70f1ddb3e0e4b3fae86183c39d10b95  luna-init-5fff640fb0b9f3e973c13d1620889b2da4c11766.tar.gz"

--- a/aports/luna/luna-init/APKBUILD
+++ b/aports/luna/luna-init/APKBUILD
@@ -1,16 +1,24 @@
 pkgname=luna-init
 pkgver=5.0.0_git20171117
-pkgrel=1
+pkgrel=2
 _commit=5fff640fb0b9f3e973c13d1620889b2da4c11766
+_artwork_commit="2cad2af027fbec6aef0d1f16226a41ccf427f44e"
 pkgdesc="Initialization and font setup files used by luna-sysmgr."
 arch="all"
 url="http://webos-ports.org"
 license="GPL-3.0+"
 depends=""
-makedepends="cmake-modules-webos python2 py2-tz"
-source="$pkgname-$_commit.tar.gz::https://github.com/webOS-ports/luna-init/archive/$_commit.tar.gz"
+makedepends="cmake-modules-webos python2 py2-tz imagemagick"
+source="$pkgname-$_commit.tar.gz::https://github.com/webOS-ports/luna-init/archive/$_commit.tar.gz
+postmarketos-artwork-$_artwork_commit.tar.gz::https://github.com/postmarketOS/artwork/archive/${_artwork_commit}.tar.gz"
 options="!check"
 builddir="$srcdir/$pkgname-$_commit"
+
+prepare() {
+	default_prepare
+	cd "$srcdir"
+	tar xzf postmarketos-artwork-$_artwork_commit.tar.gz
+}
 
 build() {
 	mkdir -p "$srcdir"/build
@@ -20,6 +28,10 @@ build() {
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DWEBOS_INSTALL_ROOT=/
 	make
+
+	# Convert a wallpaper to jpg. Unfortunately required by luna-next-cardshell.
+	# This is done here to remain consistant with the upstream luna-init package which packages the default background image for LuneOS.
+	convert "$srcdir"/artwork-"$_artwork_commit"/wallpapers/logo/postmarketos.png "$srcdir"/build/postmarketos.jpg
 }
 
 package() {
@@ -34,6 +46,12 @@ package() {
 	install -v -m 644 "$builddir"/files/conf/default-dock-positions.json "$pkgdir"/etc/palm
 	install -v -m 644 "$builddir"/files/conf/default-launcher-page-layout.json "$pkgdir"/etc/palm
 	install -v -m 644 "$builddir"/files/conf/locale.txt "$pkgdir"/etc/palm
+	
+	# Install a default background image.
+
+	install -d "$pkgdir"/media/internal/wallpapers
+	install -v -m 644 "$srcdir"/build/postmarketos.jpg "$pkgdir"/media/internal/wallpapers/LuneOS.jpg
 
 }
-sha512sums="9278b53e8358230e0979d314958a02ada6d68a68b97e253d81ffc5132901cf7aa033c8d908530cbf36c422a161a3f80cc70f1ddb3e0e4b3fae86183c39d10b95  luna-init-5fff640fb0b9f3e973c13d1620889b2da4c11766.tar.gz"
+sha512sums="9278b53e8358230e0979d314958a02ada6d68a68b97e253d81ffc5132901cf7aa033c8d908530cbf36c422a161a3f80cc70f1ddb3e0e4b3fae86183c39d10b95  luna-init-5fff640fb0b9f3e973c13d1620889b2da4c11766.tar.gz
+b86010a33332fe6c3d983e22c982e8edf232bd66d85a4999ecbeb793e24a17c98cb5a51fe476b7a484f79b76908f32d1eae066b7c99cd142f5a810ac46ade163  postmarketos-artwork-2cad2af027fbec6aef0d1f16226a41ccf427f44e.tar.gz"

--- a/aports/luna/nodejs-module-webos-dynaload/APKBUILD
+++ b/aports/luna/nodejs-module-webos-dynaload/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=nodejs-module-webos-dynaload
 pkgver=14.0.0_git20160531
-pkgrel=0
+pkgrel=1
 _commit=4eedb88e6eea69c88d30f5519d91113419cb7e71
 pkgdesc="mojo library loader for node. Provides 'webos' node module."
 arch="all"

--- a/aports/luna/nodejs-module-webos-pmlog/APKBUILD
+++ b/aports/luna/nodejs-module-webos-pmlog/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=nodejs-module-webos-pmlog
 pkgver=18.0.0_git20150424
-pkgrel=0
+pkgrel=1
 _commit=ca359ed90389c5be085e7eac0548236312743d6a
 pkgdesc="Library to allow nodejs code to talk to palm pmloglib."
 arch="all"

--- a/aports/luna/nodejs-module-webos-sysbus/APKBUILD
+++ b/aports/luna/nodejs-module-webos-sysbus/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=nodejs-module-webos-sysbus
 pkgver=31.0.0_git20160531
-pkgrel=0
+pkgrel=1
 _commit=3a77f999b78b2f686e370ec0030097665d358169
 pkgdesc="Library to allow nodejs code to talk to palm sysbus."
 arch="all"


### PR DESCRIPTION
I'm in the midst of adding on screen keyboard support, and making startup easier on real devices. I noticed that something upstream has changed, and the Node.js modules wouldn't link at runtime anymore. This causes lots of issues. Bumped pkgrel on all three to fix.

I've also included a small fix to get a default background image from postmarketos-artwork.