### PR TITLE
Add blobtools as package for tf101

### DIFF
--- a/aports/main/blobtools/APKBUILD
+++ b/aports/main/blobtools/APKBUILD
@@ -1,5 +1,5 @@
 pkgname=blobtools
-pkgver=6186e33baa10ce6f1c738d7b91eb5153743105af
+pkgver=1.0
 pkgrel=0
 pkgdesc="Tools for unpacking & repacking blobs used for updating "hidden" partitions on ASUS Transformer"
 url="https://github.com/AndroidRoot/BlobTools"
@@ -8,7 +8,7 @@ license="Apache-2.0"
 depends=""
 makedepends="cmake"
 subpackages=""
-source="$pkgname-$pkgver.tar.gz::https://github.com/AndroidRoot/BlobTools/archive/${pkgver}.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/rrooij/BlobTools/archive/${pkgver}.tar.gz"
 options="!check"
 
 builddir="$srcdir"/BlobTools-$pkgver
@@ -24,4 +24,4 @@ package() {
 	done
 }
 
-sha512sums="69e1113c1d99f1aa930cc6674d6a0473baf9648c4c3f4da37aa44cb42648a40fe15d0a4a72815baa1118bdca36b0084b4efe82ff75549d233498a5637e98508d  blobtools-6186e33baa10ce6f1c738d7b91eb5153743105af.tar.gz"
+sha512sums="758af11f81341f6aabaa2b2835f9601c414f4cc537784bd0d239d8f5165b67753d5d4e337d934a3e459b54b83ad3c3710b57e2176793356f3ee69658e626ee98  blobtools-1.0.tar.gz"

--- a/aports/main/blobtools/APKBUILD
+++ b/aports/main/blobtools/APKBUILD
@@ -1,0 +1,27 @@
+pkgname=blobtools
+pkgver=6186e33baa10ce6f1c738d7b91eb5153743105af
+pkgrel=0
+pkgdesc="Tools for unpacking & repacking blobs used for updating "hidden" partitions on ASUS Transformer"
+url="https://github.com/AndroidRoot/BlobTools"
+arch="all"
+license="Apache-2.0"
+depends=""
+makedepends="cmake"
+subpackages=""
+source="$pkgname-$pkgver.tar.gz::https://github.com/AndroidRoot/BlobTools/archive/${pkgver}.tar.gz"
+options="!check"
+
+builddir="$srcdir"/BlobTools-$pkgver
+build() {
+	cd "$builddir"
+	cmake -DCMAKE_BUILD_TYPE=Release -DDISABLE_FRONTEND=ON .
+	make
+}
+
+package() {
+	for i in "$builddir"/bin/*; do
+		install -Dm755 "$i" "$pkgdir"/usr/bin/"$(basename "$i")"
+	done
+}
+
+sha512sums="69e1113c1d99f1aa930cc6674d6a0473baf9648c4c3f4da37aa44cb42648a40fe15d0a4a72815baa1118bdca36b0084b4efe82ff75549d233498a5637e98508d  blobtools-6186e33baa10ce6f1c738d7b91eb5153743105af.tar.gz"

--- a/aports/main/blobtools/APKBUILD
+++ b/aports/main/blobtools/APKBUILD
@@ -6,7 +6,7 @@ url="https://github.com/AndroidRoot/BlobTools"
 arch="all"
 license="Apache-2.0"
 depends=""
-makedepends="cmake"
+makedepends=""
 subpackages=""
 source="$pkgname-$pkgver.tar.gz::https://github.com/rrooij/BlobTools/archive/${pkgver}.tar.gz"
 options="!check"
@@ -14,12 +14,11 @@ options="!check"
 builddir="$srcdir"/BlobTools-$pkgver
 build() {
 	cd "$builddir"
-	cmake -DCMAKE_BUILD_TYPE=Release .
 	make
 }
 
 package() {
-	for i in "$builddir"/bin/*; do
+	for i in "$builddir"/blobpack "$builddir"/blobunpack; do
 		install -Dm755 "$i" "$pkgdir"/usr/bin/"$(basename "$i")"
 	done
 }

--- a/aports/main/blobtools/APKBUILD
+++ b/aports/main/blobtools/APKBUILD
@@ -14,7 +14,7 @@ options="!check"
 builddir="$srcdir"/BlobTools-$pkgver
 build() {
 	cd "$builddir"
-	cmake -DCMAKE_BUILD_TYPE=Release -DDISABLE_FRONTEND=ON .
+	cmake -DCMAKE_BUILD_TYPE=Release .
 	make
 }
 

--- a/aports/main/blobtools/APKBUILD
+++ b/aports/main/blobtools/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=blobtools
 pkgver=1.0
 pkgrel=0
-pkgdesc="Tools for unpacking & repacking blobs used for updating "hidden" partitions on ASUS Transformer"
+pkgdesc="Tools for unpacking & repacking blobs used for updating 'hidden' partitions on ASUS Transformer"
 url="https://github.com/AndroidRoot/BlobTools"
 arch="all"
 license="Apache-2.0"

--- a/aports/main/blobtools/APKBUILD
+++ b/aports/main/blobtools/APKBUILD
@@ -1,5 +1,5 @@
 pkgname=blobtools
-pkgver=git20121024
+pkgver=0.0_git20121024
 pkgrel=0
 pkgdesc="Tools for unpacking & repacking blobs used for updating 'hidden' partitions on ASUS Transformer"
 url="https://github.com/AndroidRoot/BlobTools"

--- a/aports/main/blobtools/APKBUILD
+++ b/aports/main/blobtools/APKBUILD
@@ -1,17 +1,19 @@
 pkgname=blobtools
-pkgver=1.0
+pkgver=git20121024
 pkgrel=0
 pkgdesc="Tools for unpacking & repacking blobs used for updating 'hidden' partitions on ASUS Transformer"
 url="https://github.com/AndroidRoot/BlobTools"
 arch="all"
 license="Apache-2.0"
+options="!check"
 depends=""
 makedepends=""
 subpackages=""
-source="$pkgname-$pkgver.tar.gz::https://github.com/rrooij/BlobTools/archive/${pkgver}.tar.gz"
-options="!check"
 
-builddir="$srcdir"/BlobTools-$pkgver
+_commit=6186e33baa10ce6f1c738d7b91eb5153743105af
+source="$pkgname-$_commit.tar.gz::https://github.com/AndroidRoot/BlobTools/archive/${_commit}.tar.gz"
+
+builddir="$srcdir"/BlobTools-$_commit
 build() {
 	cd "$builddir"
 	make
@@ -23,4 +25,4 @@ package() {
 	done
 }
 
-sha512sums="758af11f81341f6aabaa2b2835f9601c414f4cc537784bd0d239d8f5165b67753d5d4e337d934a3e459b54b83ad3c3710b57e2176793356f3ee69658e626ee98  blobtools-1.0.tar.gz"
+sha512sums="69e1113c1d99f1aa930cc6674d6a0473baf9648c4c3f4da37aa44cb42648a40fe15d0a4a72815baa1118bdca36b0084b4efe82ff75549d233498a5637e98508d  blobtools-6186e33baa10ce6f1c738d7b91eb5153743105af.tar.gz"


### PR DESCRIPTION
This is for making a kernel image for the TF101 easier. See the
pull request comment by Ollieparanoid for more information:

https://github.com/postmarketOS/pmbootstrap/pull/1103#issuecomment-357035481

The TF101 does not support normal Android boot images and instead needs
a blob to be created.

This is my first package outside the device directory, so I hope I did it somewhat good. I can confirm that it builds successfully. 