### PR TITLE
Fix error message suggesting to run invalid command "zap -a"

### DIFF
--- a/pmb/chroot/apk_static.py
+++ b/pmb/chroot/apk_static.py
@@ -107,8 +107,9 @@ def verify_signature(args, files, sigkey_path):
         os.unlink(files["sig"]["temp_path"])
         os.unlink(files["apk"]["temp_path"])
         raise RuntimeError("Failed to validate signature of apk.static."
-                           " There's something wrong with the archive - run 'pmbootstrap"
-                           " zap -a' and try again!")
+                           " Either openssl is not installed, or the"
+                           " download failed. Run 'pmbootstrap zap -hc' to"
+                           " delete the download and try again.")
 
 
 def extract(args, version, apk_path):


### PR DESCRIPTION
The message showed up, when you apk-static download could not be
verified. What the user needs to do instead is checking if openssl
is installed, and possibly delete the http cache ("zap -hc").