### PR TITLE
mkinitfs: Fail on missing depends / better usability in general

### DIFF
--- a/aports/main/postmarketos-mkinitfs/APKBUILD
+++ b/aports/main/postmarketos-mkinitfs/APKBUILD
@@ -1,5 +1,5 @@
 pkgname=postmarketos-mkinitfs
-pkgver=0.5.8
+pkgver=0.5.9
 pkgrel=0
 pkgdesc="Tool to generate initramfs images for postmarketOS"
 url="https://github.com/postmarketOS"
@@ -24,4 +24,4 @@ package() {
 }
 sha512sums="500c1e903ca9cf5dfe0102414b086643379d51d848e15eeed89da8ba9f3a286dfba139a29b8312a0df005e159a54ad08c84e078b7d70e6873cabb7d0abda4807  init.sh.in
 eca1e4647494556be52b3eecffe2db75735006a6c53e8778630949808aabc464281ffa75a8744e22a5512c2de1eb5f92f9eb377a55ca4a7402ba8cc0705df83d  init_functions.sh
-77adbdc13ed562999ac02a194b2b5237f29704d3c39afa7e27c34f739c701c272a284e9a18d403bb01d02fa5123f006168f21378746a2a5a2d860f9345e51b70  mkinitfs.sh"
+6363ca98574cca9a449e1533b7aea6d8a021984e671f5cacd794110d3000153271f377e44b5316c6cc642ee1d20e239a2f5fe126bc527e307dc9257c6932b261  mkinitfs.sh"

--- a/aports/main/postmarketos-mkinitfs/postmarketos-mkinitfs.trigger
+++ b/aports/main/postmarketos-mkinitfs/postmarketos-mkinitfs.trigger
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # $1: kernel flavor
 rebuild_initfs_flavor()

--- a/pmb/config/__init__.py
+++ b/pmb/config/__init__.py
@@ -167,6 +167,7 @@ necessary_kconfig_options = {
     "DEVTMPFS": True,
     "DEVTMPFS_MOUNT": False,
     "DM_CRYPT": True,
+    "EXT4_FS": True,
     "PFT": False,
     "SYSVIPC": True,
     "VT": True


### PR DESCRIPTION
### Changes
* Fail if mkbootimg/uboot-tools are not installed, but creating a
  boot.img file / u-boot legacy image was requested via deviceinfo
  (fixes #312)
* Fail if /boot/dt.img is missing, but we have a qcdt device
* Fail if the dtb file specified in deviceinfo does not exist
* Fail if mkbootimg etc. exit with error code
* Don't try to add the ext4 module into the initramfs. We always
  compile it into the kernel. Instead, kconfig_check makes sure it
  is enabled now. (fixes #1037)
* Add a note that modprobe warnings can be ignored mostly:

```
==> initramfs: creating /boot/initramfs-amazon-thor
Scanning kernel module dependencies...
NOTE: ** modprobe warnings below can be ignored ** if your device does not run the
mainline kernel yet (most devices!) or if the related kernel options are enabled
with 'y' instead of 'm' (module).
modprobe: WARNING: Module drm_kms_helper not found in directory /lib/modules/3.4.0-perf
modprobe: WARNING: Module drm not found in directory /lib/modules/3.4.0-perf
modprobe: WARNING: Module dm_crypt not found in directory /lib/modules/3.4.0-perf
```

### Testing
I've tested `pmbootstrap -y zap; pmbootstrap initfs` with the following combinations.

1. nokia-rx51 (u-boot legacy, mainline kernel dtb) without changes
-> runs through as expected
2. nokia-rx51 missing uboot-tools:
```
==> initramfs: creating /boot/initramfs-postmarketos-stable
==> kernel: appending device-tree omap3-n900
ERROR: 'deviceinfo_generate_legacy_uboot_initfs' is set, but the package 
'uboot-tools' was not
installed! Please add 'uboot-tools' to the depends= line of your device's
APKBUILD. See also: <https://postmarketos.org/deviceinfo>
```
3. nokia-rx51 with missing dtb file:
```
==> initramfs: creating /boot/initramfs-postmarketos-stable
==> kernel: appending device-tree some-invalid-dtb-file
ERROR: File not found: /usr/share/dtb/some-invalid-dtb-file.dtb
```
4. amazon-thor without changes (bootimg, qcdt device)
-> runs through as expected
5. amazon-thor without bootimg
```
ERROR: 'deviceinfo_generate_bootimg' is set, but the package 'mkbootimg' was not
installed! Please add 'mkbootimg' to the depends= line of your device's
APKBUILD. See also: <https://postmarketos.org/deviceinfo>
```
6. amazon-thor without /boot/dt.img
```
==> initramfs: creating boot.img
ERROR: File not found: /boot/dt.img, but
'deviceinfo_bootimg_qcdt' is set. Please verify that your
device is a QCDT device by analyzing the boot.img file
(e.g. 'pmbootstrap bootimg_analyze path/to/twrp.img')
and based on that, set the deviceinfo variable to false or
adjust your linux APKBUILD to properly generate the dt.img
file. See also: <https://postmarketos.org/deviceinfo>
```


