### PR TITLE
aportgen linux: Also remove -Werror in Kbuild files

### DIFF
--- a/pmb/aportgen/linux.py
+++ b/pmb/aportgen/linux.py
@@ -101,10 +101,13 @@ def generate_apkbuild(args, pkgname, deviceinfo):
             cp -v "$srcdir/compiler-gcc6.h" "$builddir/include/linux/"
 
             # Remove -Werror from all makefiles
-            find . -type f -name Makefile -print0 | \\
-                xargs -0 sed -i 's/-Werror-/-W/g'
-            find . -type f -name Makefile -print0 | \\
-                xargs -0 sed -i 's/-Werror//g'
+            local i
+            local makefiles="$(find . -type f -name Makefile)
+                $(find . -type f -name Kbuild)"
+            for i in $makefiles; do
+                sed -i 's/-Werror-/-W/g' "$i"
+                sed -i 's/-Werror//g' "$i"
+            done
 
             # Prepare kernel config ('yes ""' for kernels lacking olddefconfig)
             cp "$srcdir"/$_config "$builddir"/.config


### PR DESCRIPTION
When generating a new kernel fork package (`linux-my-device`) with either `pmbootstrap init` or `pmbootstrap aportgen linux-my-device`, we remove the -Werror flags from all Makefiles. Because usually the kernels were built with older GCC versions, that didn't throw as many errors as the current one does, and fixing all these warnings isn't helpful for a kernel that can never be updated properly anyway (real solution being mainlining as usually).

We discovered that one kernel had it in a Kbuild file in #1124, so this PR patches it for the Kbuild files as well. I've built the kernel from that issue successfully, without the PR it errors with a -Werror, and with the PR it does not throw an error at all.