### PR TITLE
version.py: Fix validation of versions like "6.0_0002" (it's invalid!)

### DIFF
--- a/pmb/parse/version.py
+++ b/pmb/parse/version.py
@@ -113,9 +113,12 @@ def parse_suffix(rest):
     :param rest: what is left of the version string, that we are
                  currently parsing, starts with a "suffix" value
                  (see below for valid suffixes).
-    :returns: (rest, value) rest is the input "rest" string without the
-              suffix, value is a signed integer (negative for pre-,
-              positive for post-suffixes).
+    :returns: (rest, value, invalid_suffix)
+              - rest: is the input "rest" string without the suffix
+              - value: is a signed integer (negative for pre-,
+                positive for post-suffixes).
+              - invalid_suffix: is true, when rest does not start
+                with anything from the suffixes variable.
 
     C equivalent: get_token(), case TOKEN_SUFFIX
     """
@@ -132,8 +135,8 @@ def parse_suffix(rest):
             value = i
             if name == "pre":
                 value = value - len(suffixes)
-            return (rest, value)
-    return (rest, 0)
+            return (rest, value, False)
+    return (rest, 0, True)
 
 
 def get_token(previous, rest):
@@ -154,6 +157,7 @@ def get_token(previous, rest):
     # Set defaults
     value = 0
     next = "invalid"
+    invalid_suffix = False
 
     # Bail out if at the end
     if not len(rest):
@@ -180,7 +184,7 @@ def get_token(previous, rest):
         value = rest[0]
         rest = rest[1:]
     elif previous == "suffix":
-        (rest, value) = parse_suffix(rest)
+        (rest, value, invalid_suffix) = parse_suffix(rest)
 
     # Invalid previous token
     else:
@@ -189,7 +193,7 @@ def get_token(previous, rest):
     # Get the next token (for non-leading zeros)
     if(not len(rest)):
         next = "end"
-    elif(next == "invalid"):
+    elif next == "invalid" and not invalid_suffix:
         (next, rest) = next_token(previous, rest)
 
     return (next, value, rest)

--- a/test/test_version_validate.py
+++ b/test/test_version_validate.py
@@ -1,0 +1,37 @@
+"""
+Copyright 2018 Oliver Smith
+
+This file is part of pmbootstrap.
+
+pmbootstrap is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+pmbootstrap is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with pmbootstrap.  If not, see <http://www.gnu.org/licenses/>.
+"""
+import os
+import sys
+
+# Import from parent directory
+sys.path.append(os.path.realpath(
+    os.path.join(os.path.dirname(__file__) + "/..")))
+import pmb.parse.version
+
+
+def test_version_validate():
+    func = pmb.parse.version.validate
+
+    assert func("6.0_1") is False
+    assert func("6.0_invalidsuffix1") is False
+    assert func("6.0.0002") is True
+    assert func("6.0.234") is True
+
+    # Issue #1144
+    assert func("6.0_0002") is False


### PR DESCRIPTION
`pmb.parse.version.validate()` said `6.0_0002` was valid, but when asking `apk` it said it was invalid (because `0002` is not a valid version suffix).

This PR fixes it, and adds test cases for this specific case. We already have a great deal of test cases (all from `apk`), but these only check if comparing one version with another one works correctly.

@ncopa, @kaniini: From what I know, you're using `version.py` as well. So this is a heads up. Also since you guys know the `apk` code base: If you have time, maybe one of you could review this fix.

(Fixes #1144.)