### PR TITLE
Update requirements for Alpine Linux distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For in-depth information please refer to the [postmarketOS wiki](https://wiki.po
 * Linux distribution (`x86_64` or `aarch64`)
   * [Windows subsystem for Linux (WSL)](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) does **not** work! Please use [VirtualBox](https://www.virtualbox.org/) instead.
   * Kernels based on the grsec patchset [do **not** work](https://github.com/postmarketOS/pmbootstrap/issues/107) *(Alpine: use linux-vanilla instead of linux-hardened, Arch: linux-hardened [is not based on grsec](https://www.reddit.com/r/archlinux/comments/68b2jn/linuxhardened_in_community_repo_a_grsecurity/))*
-  * On Alpine Linux only: `apk add coreutils`
+  * On Alpine Linux only: `apk add coreutils grep`
 * Python 3.4+
 * OpenSSL
 


### PR DESCRIPTION
As discovered few days ago, during `pmbootstrap install` we compute the folder size which uses GNU grep, on Alpine Linux it's not installed by default.