### PR TITLE
Index parser: support multiple package providers

### DIFF
--- a/pmb/aportgen/busybox_static.py
+++ b/pmb/aportgen/busybox_static.py
@@ -26,14 +26,12 @@ import pmb.chroot.apk_static
 
 
 def generate(args, pkgname):
-    # Install busybox-static in chroot (so we have the APKINDEX and verified
-    # apks)
+    # Install busybox-static in chroot to get verified apks
     arch = pkgname.split("-")[2]
-    apkindex = pmb.chroot.apk_static.download(args, "APKINDEX.tar.gz")
     pmb.chroot.apk.install(args, ["busybox-static"], "buildroot_" + arch)
 
     # Parse version from APKINDEX
-    package_data = pmb.parse.apkindex.read(args, "busybox", apkindex)
+    package_data = pmb.parse.apkindex.package(args, "busybox")
     version = package_data["version"]
     pkgver = version.split("-r")[0]
     pkgrel = version.split("-r")[1]

--- a/pmb/aportgen/musl.py
+++ b/pmb/aportgen/musl.py
@@ -26,13 +26,12 @@ import pmb.chroot.apk_static
 
 
 def generate(args, pkgname):
-    # Install musl in chroot (so we have the APKINDEX and verified musl apks)
+    # Install musl in chroot to get verified apks
     arch = pkgname.split("-")[1]
-    apkindex = pmb.chroot.apk_static.download(args, "APKINDEX.tar.gz")
     pmb.chroot.apk.install(args, ["musl-dev"], "buildroot_" + arch)
 
     # Parse musl version from APKINDEX
-    package_data = pmb.parse.apkindex.read(args, "musl", apkindex)
+    package_data = pmb.parse.apkindex.package(args, "musl")
     version = package_data["version"]
     pkgver = version.split("-r")[0]
     pkgrel = version.split("-r")[1]

--- a/pmb/build/_package.py
+++ b/pmb/build/_package.py
@@ -61,7 +61,7 @@ def get_apkbuild(args, pkgname, arch):
     aport = pmb.build.find_aport(args, pkgname, False)
     if aport:
         return pmb.parse.apkbuild(args, aport + "/APKBUILD")
-    if pmb.parse.apkindex.read_any_index(args, pkgname, arch):
+    if pmb.parse.apkindex.providers(args, pkgname, arch, False):
         return None
     raise RuntimeError("Package '" + pkgname + "': Could not find aport, and"
                        " could not find this package in any APKINDEX!")
@@ -209,12 +209,7 @@ def get_gcc_version(args, arch):
     <https://linux.die.net/man/1/ccache>
     :returns: a string like "6.4.0-r5"
     """
-    repository = args.mirror_alpine + args.alpine_version + "/main"
-    hash = pmb.helpers.repo.hash(repository)
-    index_path = (args.work + "/cache_apk_" + arch + "/APKINDEX." +
-                  hash + ".tar.gz")
-    apkindex = pmb.parse.apkindex.read(args, "gcc", index_path, True)
-    return apkindex["version"]
+    return pmb.parse.apkindex.package(args, "gcc", arch)["version"]
 
 
 def run_abuild(args, apkbuild, arch, strict=False, force=False, cross=None,

--- a/pmb/build/other.py
+++ b/pmb/build/other.py
@@ -91,7 +91,7 @@ def copy_to_buildpath(args, package, suffix="native"):
                            "/home/pmos/build"], suffix=suffix)
 
 
-def is_necessary(args, arch, apkbuild, apkindex_path=None):
+def is_necessary(args, arch, apkbuild, indexes=None):
     """
     Check if the package has already been built. Compared to abuild's check,
     this check also works for different architectures, and it recognizes
@@ -100,7 +100,7 @@ def is_necessary(args, arch, apkbuild, apkindex_path=None):
 
     :param arch: package target architecture
     :param apkbuild: from pmb.parse.apkbuild()
-    :param apkindex_path: override the APKINDEX.tar.gz path
+    :param indexes: list of APKINDEX.tar.gz paths
     :returns: boolean
     """
     # Get package name, version, define start of debug message
@@ -109,11 +109,8 @@ def is_necessary(args, arch, apkbuild, apkindex_path=None):
     msg = "Build is necessary for package '" + package + "': "
 
     # Get old version from APKINDEX
-    if apkindex_path:
-        index_data = pmb.parse.apkindex.read(
-            args, package, apkindex_path, False)
-    else:
-        index_data = pmb.parse.apkindex.read_any_index(args, package, arch)
+    index_data = pmb.parse.apkindex.package(args, package, arch, False,
+                                            indexes)
     if not index_data:
         logging.debug(msg + "No binary package available")
         return True

--- a/pmb/chroot/apk.py
+++ b/pmb/chroot/apk.py
@@ -94,8 +94,7 @@ def check_min_version(args, suffix="native"):
     # Compare
     version_installed = installed(args, suffix)["apk-tools"]["version"]
     version_min = pmb.config.apk_tools_static_min_version
-    if pmb.parse.version.compare(version_installed,
-                                 version_min) == -1:
+    if pmb.parse.version.compare(version_installed, version_min) == -1:
         raise RuntimeError("You have an outdated version of the 'apk' package"
                            " manager installed (your version: " + version_installed +
                            ", expected at least: " + version_min + "). Delete"
@@ -124,7 +123,7 @@ def install_is_necessary(args, build, arch, package, packages_installed):
         return True
 
     # Make sure, that we really have a binary package
-    data_repo = pmb.parse.apkindex.read_any_index(args, package, arch)
+    data_repo = pmb.parse.apkindex.package(args, package, arch, False)
     if not data_repo:
         logging.warning("WARNING: Internal error in pmbootstrap," +
                         " package '" + package + "' for " + arch +
@@ -193,8 +192,7 @@ def install(args, packages, suffix="native", build=True):
 
     # Add depends to packages
     arch = pmb.parse.arch.from_chroot_suffix(args, suffix)
-    packages_with_depends = pmb.parse.depends.recurse(args, packages, arch,
-                                                      strict=True)
+    packages_with_depends = pmb.parse.depends.recurse(args, packages, suffix)
 
     # Filter outdated packages (build them if required)
     packages_installed = installed(args, suffix)
@@ -256,6 +254,4 @@ def installed(args, suffix="native"):
               }
     """
     path = args.work + "/chroot_" + suffix + "/lib/apk/db/installed"
-    if not os.path.exists(path):
-        return {}
-    return pmb.parse.apkindex.parse(args, path)
+    return pmb.parse.apkindex.parse(args, path, False)

--- a/pmb/chroot/apk_static.py
+++ b/pmb/chroot/apk_static.py
@@ -166,7 +166,8 @@ def init(args):
                 pmb.helpers.repo.hash(url) + ".tar.gz")
 
     # Extract and verify the apk-tools-static version
-    index_data = pmb.parse.apkindex.read(args, "apk-tools-static", apkindex)
+    index_data = pmb.parse.apkindex.package(args, "apk-tools-static",
+                                            indexes=[apkindex])
     version = index_data["version"]
     version_min = pmb.config.apk_tools_static_min_version
     apk_name = "apk-tools-static-" + version + ".apk"

--- a/pmb/chroot/initfs_hooks.py
+++ b/pmb/chroot/initfs_hooks.py
@@ -27,7 +27,7 @@ import pmb.chroot.apk
 def list_chroot(args, suffix, remove_prefix=True):
     ret = []
     prefix = pmb.config.initfs_hook_prefix
-    for pkgname in pmb.chroot.apk.installed(args, suffix):
+    for pkgname in pmb.chroot.apk.installed(args, suffix).keys():
         if pkgname.startswith(prefix):
             if remove_prefix:
                 ret.append(pkgname[len(prefix):])

--- a/pmb/helpers/frontend.py
+++ b/pmb/helpers/frontend.py
@@ -143,6 +143,8 @@ def checksum(args):
 def chroot(args):
     suffix = _parse_suffix(args)
     pmb.chroot.apk.check_min_version(args, suffix)
+    if args.add:
+        pmb.chroot.apk.install(args, args.add.split(","), suffix)
     logging.info("(" + suffix + ") % " + " ".join(args.command))
     pmb.chroot.root(args, args.command, suffix, log=False)
 

--- a/pmb/helpers/pkgrel_bump.py
+++ b/pmb/helpers/pkgrel_bump.py
@@ -98,8 +98,8 @@ def auto_apkindex_package(args, pkgname, aport_version, apkindex, arch,
     :returns: True when there was an APKBUILD that needed to be changed.
     """
     # Binary package
-    binary = pmb.parse.apkindex.read(args, pkgname, apkindex,
-                                     False)
+    binary = pmb.parse.apkindex.package(args, pkgname, must_exist=False,
+                                        indexes=[apkindex])
     if not binary:
         return
 
@@ -124,8 +124,9 @@ def auto_apkindex_package(args, pkgname, aport_version, apkindex, arch,
                     ",".join(binary["depends"]))
     missing = []
     for depend in binary["depends"]:
-        if not pmb.parse.apkindex.read_any_index(args, depend,
-                                                 arch):
+        providers = pmb.parse.apkindex.providers(args, depend, arch,
+                                                 must_exist=False)
+        if providers == {}:
             # We're only interested in missing depends starting with "so:"
             # (which means dynamic libraries that the package was linked
             # against) and packages for which no aport exists.

--- a/pmb/parse/arguments.py
+++ b/pmb/parse/arguments.py
@@ -249,6 +249,8 @@ def arguments():
     build_init = sub.add_parser("build_init", help="initialize build"
                                 " environment (usually you do not need to call this)")
     chroot = sub.add_parser("chroot", help="start shell in chroot")
+    chroot.add_argument("--add", help="build/install comma separated list of"
+                        " packages in the chroot before entering it")
     chroot.add_argument("command", default=["sh"], help="command"
                         " to execute inside the chroot. default: sh", nargs='*')
     for action in [build_init, chroot]:

--- a/test/test_apk_static.py
+++ b/test/test_apk_static.py
@@ -100,9 +100,7 @@ def test_signature_verification(args, tmpdir):
     if os.path.exists(args.work + "/apk.static"):
         os.remove(args.work + "/apk.static")
 
-    apk_index = pmb.chroot.apk_static.download(args, "APKINDEX.tar.gz")
-    version = pmb.parse.apkindex.read(args, "apk-tools-static",
-                                      apk_index)["version"]
+    version = pmb.parse.apkindex.package(args, "apk-tools-static")["version"]
     apk_path = pmb.chroot.apk_static.download(args,
                                               "apk-tools-static-" + version + ".apk")
 

--- a/test/test_keys.py
+++ b/test/test_keys.py
@@ -43,8 +43,7 @@ def args(request):
 def test_keys(args):
     # Get the alpine-keys apk filename
     pmb.chroot.init(args)
-    info = pmb.parse.apkindex.read_any_index(args, "alpine-keys")
-    version = info["version"]
+    version = pmb.parse.apkindex.package(args, "alpine-keys")["version"]
     pattern = (args.work + "/cache_apk_" + args.arch_native + "/alpine-keys-" +
                version + ".*.apk")
     filename = os.path.basename(glob.glob(pattern)[0])

--- a/test/test_parse_apkindex.py
+++ b/test/test_parse_apkindex.py
@@ -17,6 +17,11 @@ You should have received a copy of the GNU General Public License
 along with pmbootstrap.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+"""
+This file tests all functions from pmb.parse.apkindex.
+"""
+
+import collections
 import os
 import pytest
 import sys
@@ -40,20 +45,252 @@ def args(tmpdir, request):
     return args
 
 
-def test_read_any_index_highest_version(args, monkeypatch):
-    # Return 3 fake "files" for pmb.helpers.repo.apkindex_files()
-    def return_fake_files(*arguments):
-        return ["0", "1", "2"]
-    monkeypatch.setattr(pmb.helpers.repo, "apkindex_files",
-                        return_fake_files)
+def test_parse_next_block_exceptions(args):
+    # Mapping of input files (inside the /test/testdata/apkindex) to
+    # error message substrings
+    mapping = {"key_twice": "specified twice",
+               "key_missing": "Missing required key",
+               "new_line_missing": "does not end with a new line!"}
 
-    # Return fake index data for the "files"
-    def return_fake_read(args, package, path, must_exist=True):
-        return {"0": {"pkgname": "test", "version": "2"},
-                "1": {"pkgname": "test", "version": "3"},
-                "2": {"pkgname": "test", "version": "1"}}[path]
-    monkeypatch.setattr(pmb.parse.apkindex, "read", return_fake_read)
+    # Parse the files
+    for file, error_substr in mapping.items():
+        path = pmb.config.pmb_src + "/test/testdata/apkindex/" + file
+        with open(path, "r", encoding="utf-8") as handle:
+            lines = handle.readlines()
+
+        with pytest.raises(RuntimeError) as e:
+            pmb.parse.apkindex.parse_next_block(args, path, lines, [0])
+        assert error_substr in str(e.value)
+
+
+def test_parse_next_block_no_error(args):
+    # Read the file
+    func = pmb.parse.apkindex.parse_next_block
+    path = pmb.config.pmb_src + "/test/testdata/apkindex/no_error"
+    with open(path, "r", encoding="utf-8") as handle:
+        lines = handle.readlines()
+
+    # First block
+    start = [0]
+    block = {'arch': 'x86_64',
+             'depends': [],
+             'origin': 'musl',
+             'pkgname': 'musl',
+             'provides': ['so:libc.musl-x86_64.so.1'],
+             'timestamp': '1515217616',
+             'version': '1.1.18-r5'}
+    assert func(args, path, lines, start) == block
+    assert start == [24]
+
+    # Second block
+    block = {'arch': 'x86_64',
+             'depends': ['ca-certificates',
+                         'so:libc.musl-x86_64.so.1',
+                         'so:libcurl.so.4',
+                         'so:libz.so.1'],
+             'origin': 'curl',
+             'pkgname': 'curl',
+             'provides': ['cmd:curl'],
+             'timestamp': '1512030418',
+             'version': '7.57.0-r0'}
+    assert func(args, path, lines, start) == block
+    assert start == [45]
+
+    # No more blocks
+    assert func(args, path, lines, start) is None
+    assert start == [45]
+
+
+def test_parse_add_block(args):
+    func = pmb.parse.apkindex.parse_add_block
+    multiple_providers = False
+
+    # One package without alias
+    ret = {}
+    block = {"pkgname": "test", "version": "2"}
+    alias = None
+    func(ret, block, alias, multiple_providers)
+    assert ret == {"test": block}
+
+    # Older packages must not overwrite newer ones
+    block_old = {"pkgname": "test", "version": "1"}
+    func(ret, block_old, alias, multiple_providers)
+    assert ret == {"test": block}
+
+    # Newer packages must overwrite older ones
+    block_new = {"pkgname": "test", "version": "3"}
+    func(ret, block_new, alias, multiple_providers)
+    assert ret == {"test": block_new}
+
+    # Add package with alias
+    alias = "test_alias"
+    func(ret, block_new, alias, multiple_providers)
+    assert ret == {"test": block_new, "test_alias": block_new}
+
+
+def test_parse_add_block_multiple_providers(args):
+    func = pmb.parse.apkindex.parse_add_block
+
+    # One package without alias
+    ret = {}
+    block = {"pkgname": "test", "version": "2"}
+    alias = None
+    func(ret, block, alias)
+    assert ret == {"test": {"test": block}}
+
+    # Older packages must not overwrite newer ones
+    block_old = {"pkgname": "test", "version": "1"}
+    func(ret, block_old, alias)
+    assert ret == {"test": {"test": block}}
+
+    # Newer packages must overwrite older ones
+    block_new = {"pkgname": "test", "version": "3"}
+    func(ret, block_new, alias)
+    assert ret == {"test": {"test": block_new}}
+
+    # Add package with alias
+    alias = "test_alias"
+    func(ret, block_new, alias)
+    assert ret == {"test": {"test": block_new},
+                   "test_alias": {"test": block_new}}
+
+    # Add another package with the same alias
+    alias = "test_alias"
+    block_test2 = {"pkgname": "test2", "version": "1"}
+    func(ret, block_test2, alias)
+    assert ret == {"test": {"test": block_new},
+                   "test_alias": {"test": block_new, "test2": block_test2}}
+
+
+def test_parse_invalid_path(args):
+    assert pmb.parse.apkindex.parse(args, "/invalid/path/APKINDEX") == {}
+
+
+def test_parse_cached(args, tmpdir):
+    # Create a real file (cache looks at the last modified date)
+    path = str(tmpdir) + "/APKINDEX"
+    pmb.helpers.run.user(args, ["touch", path])
+    lastmod = os.path.getmtime(path)
+
+    # Fill the cache
+    args.cache["apkindex"][path] = {
+        "lastmod": lastmod,
+        "multiple": "cached_result_multiple",
+        "single": "cached_result_single",
+    }
+
+    # Verify cache usage
+    func = pmb.parse.apkindex.parse
+    assert func(args, path, True) == "cached_result_multiple"
+    assert func(args, path, False) == "cached_result_single"
+
+    # Make cache invalid
+    args.cache["apkindex"][path]["lastmod"] -= 10
+    assert func(args, path, True) == {}
+
+    # Delete the cache (run twice for both code paths)
+    assert pmb.parse.apkindex.clear_cache(args, path) is True
+    assert args.cache["apkindex"] == {}
+    assert pmb.parse.apkindex.clear_cache(args, path) is False
+
+
+def test_parse(args):
+    path = pmb.config.pmb_src + "/test/testdata/apkindex/no_error"
+    block_musl = {'arch': 'x86_64',
+                  'depends': [],
+                  'origin': 'musl',
+                  'pkgname': 'musl',
+                  'provides': ['so:libc.musl-x86_64.so.1'],
+                  'timestamp': '1515217616',
+                  'version': '1.1.18-r5'}
+    block_curl = {'arch': 'x86_64',
+                  'depends': ['ca-certificates',
+                              'so:libc.musl-x86_64.so.1',
+                              'so:libcurl.so.4',
+                              'so:libz.so.1'],
+                  'origin': 'curl',
+                  'pkgname': 'curl',
+                  'provides': ['cmd:curl'],
+                  'timestamp': '1512030418',
+                  'version': '7.57.0-r0'}
+
+    # Test without multiple_providers
+    ret_single = {'cmd:curl': block_curl,
+                  'curl': block_curl,
+                  'musl': block_musl,
+                  'so:libc.musl-x86_64.so.1': block_musl}
+    assert pmb.parse.apkindex.parse(args, path, False) == ret_single
+    assert args.cache["apkindex"][path]["single"] == ret_single
+
+    # Test with multiple_providers
+    ret_multiple = {'cmd:curl': {"curl": block_curl},
+                    'curl': {"curl": block_curl},
+                    'musl': {"musl": block_musl},
+                    'so:libc.musl-x86_64.so.1': {"musl": block_musl}}
+    assert pmb.parse.apkindex.parse(args, path, True) == ret_multiple
+    assert args.cache["apkindex"][path]["multiple"] == ret_multiple
+
+
+def test_providers_invalid_package(args, tmpdir):
+    # Create empty APKINDEX
+    path = str(tmpdir) + "/APKINDEX"
+    pmb.helpers.run.user(args, ["touch", path])
+
+    # Test with must_exist=False
+    func = pmb.parse.apkindex.providers
+    package = "test"
+    indexes = [path]
+    assert func(args, package, None, False, indexes) == {}
+
+    # Test with must_exist=True
+    with pytest.raises(RuntimeError) as e:
+        func(args, package, None, True, indexes)
+    assert str(e.value).startswith("Could not find package")
+
+
+def test_providers_highest_version(args, monkeypatch):
+    """
+    In this test, we simulate 3 APKINDEX files ("i0", "i1", "i2" instead of
+    full paths to real APKINDEX.tar.gz files), and each of them has a different
+    version of the same package. The highest version must win, no matter in
+    which order the APKINDEX files are processed.
+    """
+    # Fake parse function
+    def return_fake_parse(args, path):
+        version_mapping = {"i0": "2", "i1": "3", "i2": "1"}
+        package_block = {"pkgname": "test", "version": version_mapping[path]}
+        return {"test": {"test": package_block}}
+    monkeypatch.setattr(pmb.parse.apkindex, "parse", return_fake_parse)
 
     # Verify that it picks the highest version
-    func = pmb.parse.apkindex.read_any_index
-    assert func(args, "test")["version"] == "3"
+    func = pmb.parse.apkindex.providers
+    providers = func(args, "test", indexes=["i0", "i1", "i2"])
+    assert providers["test"]["version"] == "3"
+
+
+def test_package(args, monkeypatch):
+    # Override pmb.parse.apkindex.providers()
+    providers = collections.OrderedDict()
+
+    def return_providers(*args, **kwargs):
+        return providers
+    monkeypatch.setattr(pmb.parse.apkindex, "providers", return_providers)
+
+    # Provider with the same pkgname
+    func = pmb.parse.apkindex.package
+    pkgname = "test"
+    providers = {"test2": {"pkgname": "test2"}, "test": {"pkgname": "test"}}
+    assert func(args, pkgname) == {"pkgname": "test"}
+
+    # First provider
+    providers = {"test2": {"pkgname": "test2"}, "test3": {"pkgname": "test3"}}
+    assert func(args, pkgname) == {"pkgname": "test2"}
+
+    # No provider (with must_exist)
+    providers = {}
+    with pytest.raises(RuntimeError) as e:
+        func(args, pkgname)
+    assert "not found in any APKINDEX" in str(e.value)
+
+    # No provider (without must_exist)
+    assert func(args, pkgname, must_exist=False) is None

--- a/test/test_parse_depends.py
+++ b/test/test_parse_depends.py
@@ -1,0 +1,177 @@
+"""
+Copyright 2018 Oliver Smith
+
+This file is part of pmbootstrap.
+
+pmbootstrap is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+pmbootstrap is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with pmbootstrap.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+"""
+This file tests all functions from pmb.parse.depends.
+"""
+
+import collections
+import os
+import pytest
+import sys
+
+# Import from parent directory
+sys.path.append(os.path.realpath(
+    os.path.join(os.path.dirname(__file__) + "/..")))
+import pmb.config
+import pmb.config.init
+import pmb.helpers.logging
+import pmb.parse.depends
+
+
+@pytest.fixture
+def args(tmpdir, request):
+    import pmb.parse
+    sys.argv = ["pmbootstrap", "init"]
+    args = pmb.parse.arguments()
+    args.log = args.work + "/log_testsuite.txt"
+    pmb.helpers.logging.init(args)
+    request.addfinalizer(args.logfd.close)
+    return args
+
+
+def test_package_from_aports(args):
+    func = pmb.parse.depends.package_from_aports
+    assert func(args, "invalid-package") is None
+    assert func(args, "hello-world") == {"pkgname": "hello-world",
+                                         "depends": [],
+                                         "version": "1-r4"}
+
+
+def test_package_provider(args, monkeypatch):
+    # Override pmb.parse.apkindex.providers()
+    providers = collections.OrderedDict()
+
+    def return_providers(*args, **kwargs):
+        return providers
+    monkeypatch.setattr(pmb.parse.apkindex, "providers", return_providers)
+
+    # Override pmb.chroot.apk.installed()
+    installed = {}
+
+    def return_installed(*args, **kwards):
+        return installed
+    monkeypatch.setattr(pmb.chroot.apk, "installed", return_installed)
+
+    # 0. No provider
+    pkgname = "test"
+    pkgnames_install = []
+    func = pmb.parse.depends.package_provider
+    assert func(args, pkgname, pkgnames_install) is None
+
+    # 1. Only one provider
+    package = {"pkgname": "test", "version": "1234"}
+    providers = {"test": package}
+    assert func(args, pkgname, pkgnames_install) == package
+
+    # 2. Provider with the same package name
+    package_two = {"pkgname": "test-two", "provides": ["test"]}
+    providers = {"test-two": package_two, "test": package}
+    assert func(args, pkgname, pkgnames_install) == package
+
+    # 3. Pick a package, that will be installed anyway
+    providers = {"test_": package, "test-two": package_two}
+    installed = {"test_": package}
+    pkgnames_install = ["test-two"]
+    assert func(args, pkgname, pkgnames_install) == package_two
+
+    # 4. Pick a package, that is already installed
+    pkgnames_install = []
+    assert func(args, pkgname, pkgnames_install) == package
+
+    # 5. Pick the first one
+    installed = {}
+    assert func(args, pkgname, pkgnames_install) == package
+
+
+def test_package_from_index(args, monkeypatch):
+    # Override pmb.parse.depends.package_provider()
+    provider = None
+
+    def return_provider(*args, **kwargs):
+        return provider
+    monkeypatch.setattr(pmb.parse.depends, "package_provider",
+                        return_provider)
+
+    func = pmb.parse.depends.package_from_index
+    aport = {"pkgname": "test", "version": "2"}
+    pkgname = "test"
+    pkgnames_install = []
+
+    # No binary package providers
+    assert func(args, pkgname, pkgnames_install, aport) is aport
+
+    # Binary package outdated
+    provider = {"pkgname": "test", "version": "1"}
+    assert func(args, pkgname, pkgnames_install, aport) is aport
+
+    # Binary package up-to-date
+    for version in ["2", "3"]:
+        provider = {"pkgname": "test", "version": version}
+        assert func(args, pkgname, pkgnames_install, aport) is provider
+
+
+def test_recurse_invalid(args, monkeypatch):
+    func = pmb.parse.depends.recurse
+
+    # Invalid package
+    with pytest.raises(RuntimeError) as e:
+        func(args, ["invalid-pkgname"])
+    assert str(e.value).startswith("Could not find package")
+
+
+def return_none(*args, **kwargs):
+    return None
+
+
+def test_recurse(args, monkeypatch):
+    """
+    Test recursing through the following dependencies:
+
+    test:
+        libtest
+        so:libtest.so.1
+    libtest:
+        libtest_depend
+    libtest_depend:
+    so:libtest.so.1:
+        libtest_depend
+    """
+    # Override finding the package in aports: always no result
+    monkeypatch.setattr(pmb.parse.depends, "package_from_aports",
+                        return_none)
+
+    # Override depends returned from APKINDEX
+    depends = {
+        "test": ["libtest", "so:libtest.so.1"],
+        "libtest": ["libtest_depend"],
+        "libtest_depend": [],
+        "so:libtest.so.1": ["libtest_depend"],
+    }
+
+    def package_from_index(args, pkgname, install, aport, suffix):
+        return {"pkgname": pkgname, "depends": depends[pkgname]}
+    monkeypatch.setattr(pmb.parse.depends, "package_from_index",
+                        package_from_index)
+
+    # Run
+    func = pmb.parse.depends.recurse
+    pkgnames = ["test", "so:libtest.so.1"]
+    result = ["test", "so:libtest.so.1", "libtest", "libtest_depend"]
+    assert func(args, pkgnames) == result

--- a/test/test_upstream_compatibility.py
+++ b/test/test_upstream_compatibility.py
@@ -51,7 +51,8 @@ def test_qt_versions(args):
     hash = pmb.helpers.repo.hash(repository)
     index_path = (args.work + "/cache_apk_armhf/APKINDEX." + hash +
                   ".tar.gz")
-    index_data = pmb.parse.apkindex.read(args, "qt5-qtbase", index_path)
+    index_data = pmb.parse.apkindex.package(args, "qt5-qtbase",
+                                            indexes=[index_path])
     pkgver_upstream = index_data["version"].split("-r")[0]
 
     # Iterate over our packages
@@ -101,7 +102,8 @@ def test_aportgen_versions(args):
     generated = "# Automatically generated aport, do not edit!"
     for pkgname, pattern in map.items():
         # Upstream version
-        index_data = pmb.parse.apkindex.read(args, pkgname, index_path)
+        index_data = pmb.parse.apkindex.package(args, pkgname,
+                                                indexes=[index_path])
         version_upstream = index_data["version"]
 
         # Iterate over our packages

--- a/test/testdata/apkindex/key_missing
+++ b/test/testdata/apkindex/key_missing
@@ -1,0 +1,23 @@
+C:Q1gKkFdQUwKAmcUpGY8VaErq0uHNo=
+P:musl
+A:x86_64
+S:357094
+I:581632
+T:the musl c library (libc) implementation
+U:http://www.musl-libc.org/
+L:MIT
+o:musl
+m:Timo Ter  s <timo.teras@iki.fi>
+t:1515217616
+c:6cc1d4e6ac35607dd09003e4d013a0d9c4800c49
+p:so:libc.musl-x86_64.so.1=1
+F:lib
+R:libc.musl-x86_64.so.1
+a:0:0:777
+Z:Q17yJ3JFNypA4mxhJJr0ou6CzsJVI=
+R:ld-musl-x86_64.so.1
+a:0:0:755
+Z:Q1DadJ0cqdT+ImyeY5FgTdZWaLnyQ=
+F:usr
+F:usr/lib
+

--- a/test/testdata/apkindex/key_twice
+++ b/test/testdata/apkindex/key_twice
@@ -1,0 +1,25 @@
+C:Q1gKkFdQUwKAmcUpGY8VaErq0uHNo=
+P:musl
+V:1.1.18-r5
+V:1.1.18-r5
+A:x86_64
+S:357094
+I:581632
+T:the musl c library (libc) implementation
+U:http://www.musl-libc.org/
+L:MIT
+o:musl
+m:Timo Ter  s <timo.teras@iki.fi>
+t:1515217616
+c:6cc1d4e6ac35607dd09003e4d013a0d9c4800c49
+p:so:libc.musl-x86_64.so.1=1
+F:lib
+R:libc.musl-x86_64.so.1
+a:0:0:777
+Z:Q17yJ3JFNypA4mxhJJr0ou6CzsJVI=
+R:ld-musl-x86_64.so.1
+a:0:0:755
+Z:Q1DadJ0cqdT+ImyeY5FgTdZWaLnyQ=
+F:usr
+F:usr/lib
+

--- a/test/testdata/apkindex/new_line_missing
+++ b/test/testdata/apkindex/new_line_missing
@@ -1,0 +1,23 @@
+C:Q1gKkFdQUwKAmcUpGY8VaErq0uHNo=
+P:musl
+V:1.1.18-r5
+A:x86_64
+S:357094
+I:581632
+T:the musl c library (libc) implementation
+U:http://www.musl-libc.org/
+L:MIT
+o:musl
+m:Timo Ter  s <timo.teras@iki.fi>
+t:1515217616
+c:6cc1d4e6ac35607dd09003e4d013a0d9c4800c49
+p:so:libc.musl-x86_64.so.1=1
+F:lib
+R:libc.musl-x86_64.so.1
+a:0:0:777
+Z:Q17yJ3JFNypA4mxhJJr0ou6CzsJVI=
+R:ld-musl-x86_64.so.1
+a:0:0:755
+Z:Q1DadJ0cqdT+ImyeY5FgTdZWaLnyQ=
+F:usr
+F:usr/lib

--- a/test/testdata/apkindex/no_error
+++ b/test/testdata/apkindex/no_error
@@ -1,0 +1,45 @@
+C:Q1gKkFdQUwKAmcUpGY8VaErq0uHNo=
+P:musl
+V:1.1.18-r5
+A:x86_64
+S:357094
+I:581632
+T:the musl c library (libc) implementation
+U:http://www.musl-libc.org/
+L:MIT
+o:musl
+m:Timo Ter  s <timo.teras@iki.fi>
+t:1515217616
+c:6cc1d4e6ac35607dd09003e4d013a0d9c4800c49
+p:so:libc.musl-x86_64.so.1=1
+F:lib
+R:libc.musl-x86_64.so.1
+a:0:0:777
+Z:Q17yJ3JFNypA4mxhJJr0ou6CzsJVI=
+R:ld-musl-x86_64.so.1
+a:0:0:755
+Z:Q1DadJ0cqdT+ImyeY5FgTdZWaLnyQ=
+F:usr
+F:usr/lib
+
+C:Q1iundrWyXyQtSTZ9h2qqh44cZcYA=
+P:curl
+V:7.57.0-r0
+A:x86_64
+S:118233
+I:217088
+T:An URL retrival utility and library
+U:http://curl.haxx.se
+L:MIT
+o:curl
+m:Natanael Copa <ncopa@alpinelinux.org>
+t:1512030418
+c:d19c5b26c70a3055c5d6c7d2f15587f62a33a1fe
+D:ca-certificates so:libc.musl-x86_64.so.1 so:libcurl.so.4 so:libz.so.1
+p:cmd:curl
+F:usr
+F:usr/bin
+R:curl
+a:0:0:755
+Z:Q1tlqDmZcIJJXo+ScFT6Nd31EPrBM=
+


### PR DESCRIPTION
* The APKINDEX parser used to return a dictionary with one package for
  a given package name. This works for the installed packages database,
  because there can only be one provider for a package. But when
  parsing packages from binary repositories, we need to support
  multiple providers for one package. It is now possible to get a
  dictionary with either multiple providers, or just a single provider
  for each package.
* Dependency parsing logic has been adjusted, to support multiple
  providers. For multiple providers, the one with the same package
  name as the package we are looking up is prefered. If there is none
  (eg. "so:libEGL.so.1" is provided by "mesa-egl"), it prefers packages
  that will be installed anyway, and after that packages that are
  already installed. When all else fails, it just picks the first one
  and prints a note in the "pmbootstrap log".
* Added testcases for all functions in pmb.parse.apkindex and
  pmb.parse.depends
* pmbootstrap chroot has a new "--add" parameter to specify packages
  that pmbootstrap should build if neccessary, and install in the
  chroot. This can be used to quickly test the depencency resolution
  of pmbootstrap without doing a full "pmbootstrap install".

Fixes #1122.

@NotKit: Could you review/test this?