### PR TITLE
Automatically generate a calibration matrix for libinput

### DIFF
--- a/aports/device/device-asus-tf101/APKBUILD
+++ b/aports/device/device-asus-tf101/APKBUILD
@@ -2,7 +2,7 @@
 pkgname="device-asus-tf101"
 pkgdesc="Asus Eee Pad Transformer"
 pkgver=0.2
-pkgrel=0
+pkgrel=1
 url="https://postmarketos.org"
 license="MIT"
 arch="noarch"

--- a/aports/device/device-leeco-s2/APKBUILD
+++ b/aports/device/device-leeco-s2/APKBUILD
@@ -2,7 +2,7 @@
 pkgname="device-leeco-s2"
 pkgdesc="LeEco Le 2"
 pkgver=0.1
-pkgrel=1
+pkgrel=2
 url="https://postmarketos.org"
 license="MIT"
 arch="noarch"

--- a/aports/device/device-lg-h815/APKBUILD
+++ b/aports/device/device-lg-h815/APKBUILD
@@ -2,7 +2,7 @@
 pkgname="device-lg-h815"
 pkgdesc="LG G4 (h815)"
 pkgver=0.1
-pkgrel=1
+pkgrel=2
 url="https://postmarketos.org"
 license="MIT"
 arch="noarch"

--- a/aports/device/device-motorola-potter/APKBUILD
+++ b/aports/device/device-motorola-potter/APKBUILD
@@ -2,7 +2,7 @@
 pkgname="device-motorola-potter"
 pkgdesc="Motorola Moto G5 Plus"
 pkgver=0.1
-pkgrel=1
+pkgrel=2
 url="https://postmarketos.org"
 license="MIT"
 arch="noarch"

--- a/aports/device/device-motorola-shamu/APKBUILD
+++ b/aports/device/device-motorola-shamu/APKBUILD
@@ -2,7 +2,7 @@
 pkgname="device-motorola-shamu"
 pkgdesc="Motorola Google Nexus 6"
 pkgver=0.3
-pkgrel=0
+pkgrel=1
 url="https://postmarketos.org"
 license="MIT"
 arch="noarch"

--- a/aports/device/device-samsung-espresso10/APKBUILD
+++ b/aports/device/device-samsung-espresso10/APKBUILD
@@ -2,7 +2,7 @@
 pkgname="device-samsung-espresso10"
 pkgdesc="Samsung Galaxy Tab 2 (10.1 inch)"
 pkgver=0.1
-pkgrel=2
+pkgrel=3
 url="https://postmarketos.org"
 license="MIT"
 arch="noarch"

--- a/aports/device/device-samsung-i9070/APKBUILD
+++ b/aports/device/device-samsung-i9070/APKBUILD
@@ -1,7 +1,7 @@
 # Reference: <https://postmarketos.org/devicepkg>
 pkgname=device-samsung-i9070
 pkgver=1
-pkgrel=19
+pkgrel=20
 pkgdesc="Samsung Galaxy S Advance"
 url="https://github.com/postmarketOS"
 arch="noarch"

--- a/aports/device/device-samsung-i9195/APKBUILD
+++ b/aports/device/device-samsung-i9195/APKBUILD
@@ -2,7 +2,7 @@
 pkgname="device-samsung-i9195"
 pkgdesc="Samsung Galaxy S4 Mini"
 pkgver=0.2
-pkgrel=0
+pkgrel=1
 url="https://postmarketos.org"
 license="MIT"
 arch="noarch"

--- a/aports/device/device-samsung-maguro/APKBUILD
+++ b/aports/device/device-samsung-maguro/APKBUILD
@@ -1,7 +1,7 @@
 # Reference: <https://postmarketos.org/devicepkg>
 pkgname=device-samsung-maguro
 pkgver=2
-pkgrel=16
+pkgrel=17
 pkgdesc="Google Galaxy Nexus (GSM)"
 url="https://github.com/postmarketOS"
 arch="noarch"

--- a/aports/device/device-samsung-manta/APKBUILD
+++ b/aports/device/device-samsung-manta/APKBUILD
@@ -2,7 +2,7 @@
 pkgname="device-samsung-manta"
 pkgdesc="Google Nexus 10"
 pkgver=0.1
-pkgrel=0
+pkgrel=1
 url="https://postmarketos.org"
 license="MIT"
 arch="noarch"

--- a/aports/device/device-samsung-s6500d/APKBUILD
+++ b/aports/device/device-samsung-s6500d/APKBUILD
@@ -2,7 +2,7 @@
 pkgname="device-samsung-s6500d"
 pkgdesc="Samsung Galaxy Mini 2"
 pkgver=0.1
-pkgrel=1
+pkgrel=2
 url="https://postmarketos.org"
 license="MIT"
 arch="noarch"

--- a/aports/device/device-semc-anzu/APKBUILD
+++ b/aports/device/device-semc-anzu/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=device-semc-anzu
 pkgdesc="Xperia Arc"
 pkgver=1
-pkgrel=0
+pkgrel=1
 url="https://postmarketos.org"
 license="MIT"
 arch="noarch"

--- a/aports/device/device-teclast-x80pro/APKBUILD
+++ b/aports/device/device-teclast-x80pro/APKBUILD
@@ -4,7 +4,7 @@
 pkgname="device-teclast-x80pro"
 pkgdesc="Teclast X80Pro"
 pkgver=1.0
-pkgrel=0
+pkgrel=1
 url="https://postmarketos.org"
 license="MIT"
 arch="noarch"

--- a/aports/device/device-xiaomi-ido/APKBUILD
+++ b/aports/device/device-xiaomi-ido/APKBUILD
@@ -2,7 +2,7 @@
 pkgname="device-xiaomi-ido"
 pkgdesc="Xiaomi Xiaomi RedMi 3"
 pkgver=0.1
-pkgrel=1
+pkgrel=2
 url="https://postmarketos.org"
 license="MIT"
 arch="noarch"

--- a/aports/main/devicepkg-dev/APKBUILD
+++ b/aports/main/devicepkg-dev/APKBUILD
@@ -1,5 +1,5 @@
 pkgname="devicepkg-dev"
-pkgver=0.1
+pkgver=0.2
 pkgrel=0
 pkgdesc="Provides default device package functions"
 url="https://github.com/postmarketOS"
@@ -16,5 +16,5 @@ package() {
 	install -Dm755 "$srcdir/devicepkg_package.sh" \
 		"$pkgdir/usr/bin/devicepkg_package"
 }
-sha512sums="e6f96f8942fa8124ca7461bcf9c78879e08ef00da4a728735046503cae86548505594e078eb14056af74616b17332474f1473f72127299773e075bfd970af13b  devicepkg_build.sh
+sha512sums="9316aad68cf4db3f17cf11511673e16c9cbc02d75cf7963ba2f1daf6cfa6fbd9342b1d739b73e745fb076250db0a3921ae4eedec58efc70acc06a1c6614039c2  devicepkg_build.sh
 c732792596f56860f6ab9ddd53b9a7a80224400dd20097b20cebe17a6e7330e9178783f09db16132a28a555f83e29ef3643bfe069638b62998912a9a7ffefdc0  devicepkg_package.sh"

--- a/aports/main/devicepkg-dev/APKBUILD
+++ b/aports/main/devicepkg-dev/APKBUILD
@@ -16,5 +16,5 @@ package() {
 	install -Dm755 "$srcdir/devicepkg_package.sh" \
 		"$pkgdir/usr/bin/devicepkg_package"
 }
-sha512sums="8bb8b73c87da35eb024d65caecc66b6cc1d36e60f10a4413808d176ec3427931ef0b2ee08570ef1ed160002c086ad7047d116dc25d5208f0da2c90745cfb5cd5  devicepkg_build.sh
+sha512sums="638d50e6388eabf0da6bf0cff2fe9719ad8a808946f0077228db57fa13a26d9eeb39c1f2689c9a6f93ff9b3bcfdcfb7c358b180bba90e5bba8b9a9e78d25ed18  devicepkg_build.sh
 c732792596f56860f6ab9ddd53b9a7a80224400dd20097b20cebe17a6e7330e9178783f09db16132a28a555f83e29ef3643bfe069638b62998912a9a7ffefdc0  devicepkg_package.sh"

--- a/aports/main/devicepkg-dev/APKBUILD
+++ b/aports/main/devicepkg-dev/APKBUILD
@@ -16,5 +16,5 @@ package() {
 	install -Dm755 "$srcdir/devicepkg_package.sh" \
 		"$pkgdir/usr/bin/devicepkg_package"
 }
-sha512sums="9316aad68cf4db3f17cf11511673e16c9cbc02d75cf7963ba2f1daf6cfa6fbd9342b1d739b73e745fb076250db0a3921ae4eedec58efc70acc06a1c6614039c2  devicepkg_build.sh
+sha512sums="8bb8b73c87da35eb024d65caecc66b6cc1d36e60f10a4413808d176ec3427931ef0b2ee08570ef1ed160002c086ad7047d116dc25d5208f0da2c90745cfb5cd5  devicepkg_build.sh
 c732792596f56860f6ab9ddd53b9a7a80224400dd20097b20cebe17a6e7330e9178783f09db16132a28a555f83e29ef3643bfe069638b62998912a9a7ffefdc0  devicepkg_package.sh"

--- a/aports/main/devicepkg-dev/devicepkg_build.sh
+++ b/aports/main/devicepkg-dev/devicepkg_build.sh
@@ -20,6 +20,22 @@ fi
 # shellcheck disable=SC1090,SC1091
 . "$srcdir/deviceinfo"
 
+echo_libinput_calibration()
+{
+	# shellcheck disable=SC2154
+	if [ $# -eq 6 ] && [ ! -z "$deviceinfo_screen_width" ] && [ ! -z "$deviceinfo_screen_height" ]
+	then
+		# shellcheck disable=SC2154
+		x_offset=$(dc "$3" "$deviceinfo_screen_width" / p)
+		# shellcheck disable=SC2154
+		y_offset=$(dc "$6" "$deviceinfo_screen_height" / p)
+		if [ ! -z "$x_offset" ] && [ ! -z "$y_offset" ]
+		then
+			echo "ENV{LIBINPUT_CALIBRATION_MATRIX}=\"$1 $2 $x_offset $4 $5 $y_offset\", \\"
+		fi
+	fi
+}
+
 # shellcheck disable=SC2154
 if [ ! -z "$deviceinfo_dev_touchscreen" ]; then
 	# Create touchscreen udev rule
@@ -28,6 +44,8 @@ if [ ! -z "$deviceinfo_dev_touchscreen" ]; then
 		# shellcheck disable=SC2154
 		if [ ! -z "$deviceinfo_dev_touchscreen_calibration" ]; then
 			echo "ENV{WL_CALIBRATION}=\"$deviceinfo_dev_touchscreen_calibration\", \\"
+			# shellcheck disable=SC2086
+			echo_libinput_calibration $deviceinfo_dev_touchscreen_calibration
 		fi
 		echo "ENV{ID_INPUT}=\"1\", ENV{ID_INPUT_TOUCHSCREEN}=\"1\""
 	} > "$srcdir/90-$pkgname.rules"

--- a/aports/main/devicepkg-dev/devicepkg_build.sh
+++ b/aports/main/devicepkg-dev/devicepkg_build.sh
@@ -33,14 +33,16 @@ echo_libinput_calibration()
 {
 	# Check if we have got the required number of parameters.
 	if [ $# -ne 6 ]; then
-		echo "Warning: There must be exactly 6 (or 0) values for the touchscreen calibration. No calibration matrix for x11/libinput will be generated." >&2
+		echo "WARNING: There must be exactly 6 (or 0) values for the touchscreen calibration." >&2
+		echo "WARNING: No calibration matrix for x11/libinput will be generated." >&2
 		return
 	fi
 
 	# Check if we have got a screen width and screen height.
 	# shellcheck disable=SC2154
 	if [ -z "$deviceinfo_screen_width" ] || [ -z "$deviceinfo_screen_height" ]; then
-		echo "Warning: Screen width and height are required to generate a calibration matrix for x11/libinput. No calibration matrix for x11/libinput will be generated." >&2
+		echo "WARNING: Screen width and height are required to generate a calibration matrix for x11/libinput." >&2
+		echo "WARNING: No calibration matrix for x11/libinput will be generated." >&2
 		return
 	fi
 
@@ -54,7 +56,8 @@ echo_libinput_calibration()
 	# Check if we have got results from dc. If there was an error, dc should have
 	# printed an error message that hopefully gives the user a hint why it failed.
 	if [ -z "$x_offset" ] || [ -z "$y_offset" ]; then
-		echo "Warning: Calculating the offsets for the calibration matrix for x11/libinput failed. No calibration matrix for x11/libinput will be generated." >&2
+		echo "WARNING: Calculating the offsets for the calibration matrix for x11/libinput failed." >&2
+		echo "No calibration matrix for x11/libinput will be generated." >&2
 		return
 	fi
 


### PR DESCRIPTION
This takes the calibration matrix for Wayland and divides the pixel offsets by the device width/height. This is necessary as libinput for X.org seems to use coordinates between 0 and 1.

Please discuss if this is the right approach, if there should be more precautions/checks and what kind of tests would be necessary. I have only tested this for my own device (Samsung Galaxy Note 8.0). The configuration for the Nokia N900 is another example for a device with a non-trivial calibration matrix that is also adjusted for libinput for X.org.