### PR TITLE
Fix screwed up progress bars in Travis output

### DIFF
--- a/aports/main/hello-world/APKBUILD
+++ b/aports/main/hello-world/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=hello-world
 pkgver=1
-pkgrel=5
+pkgrel=4
 pkgdesc="hello world program to be built in the testsuite"
 url="https://en.wikipedia.org/wiki/%22Hello,_World!%22_program"
 arch="all"

--- a/aports/main/hello-world/APKBUILD
+++ b/aports/main/hello-world/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=hello-world
 pkgver=1
-pkgrel=4
+pkgrel=5
 pkgdesc="hello world program to be built in the testsuite"
 url="https://en.wikipedia.org/wiki/%22Hello,_World!%22_program"
 arch="all"

--- a/pmb/chroot/init.py
+++ b/pmb/chroot/init.py
@@ -135,7 +135,7 @@ def init(args, suffix="native"):
                                     chroot + "/usr/bin/qemu-" + arch_debian + "-static"])
 
     # Install alpine-base (no clean exit for non-native chroot!)
-    pmb.chroot.apk_static.run(args, ["--root", chroot,
+    pmb.chroot.apk_static.run(args, ["--no-progress", "--root", chroot,
                                      "--cache-dir", apk_cache, "--initdb", "--arch", arch,
                                      "add", "alpine-base"])
 

--- a/test/check_checksums.py
+++ b/test/check_checksums.py
@@ -64,14 +64,16 @@ def check_checksums(package):
 
 
 def check_build(packages):
-    command = (["./pmbootstrap.py", "--details-to-stdout", "build",
-                "--strict"] + list(packages))
-    try:
-        process = subprocess.Popen(command)
-        process.communicate()
-    except subprocess.CalledProcessError as e:
-        print("** Building failed")
-        exit(1)
+    # Initialize build environment with less logging
+    commands = [["build_init"],
+                ["--details-to-stdout", "build", "--strict"] + list(packages)]
+    for command in commands:
+        try:
+            process = subprocess.Popen(["./pmbootstrap.py"] + command)
+            process.communicate()
+        except subprocess.CalledProcessError as e:
+            print("** Building failed")
+            exit(1)
 
 
 if __name__ == "__main__":

--- a/test/test_build_package.py
+++ b/test/test_build_package.py
@@ -212,19 +212,21 @@ def test_run_abuild(args, monkeypatch):
 
     # Normal run
     output = "armhf/test-1-r2.apk"
-    env = {"CARCH": "armhf"}
-    cmd = ["CARCH=armhf", "abuild", "-d"]
+    env = {"CARCH": "armhf", "SUDO_APK": "abuild-apk --no-progress"}
+    sudo_apk = "SUDO_APK='abuild-apk --no-progress'"
+    cmd = ["CARCH=armhf", sudo_apk, "abuild", "-d"]
     assert func(args, apkbuild, "armhf") == (output, cmd, env)
 
     # Force and strict
-    cmd = ["CARCH=armhf", "abuild", "-r", "-f"]
+    cmd = ["CARCH=armhf", sudo_apk, "abuild", "-r", "-f"]
     assert func(args, apkbuild, "armhf", True, True) == (output, cmd, env)
 
     # cross=native
     env = {"CARCH": "armhf",
+           "SUDO_APK": "abuild-apk --no-progress",
            "CROSS_COMPILE": "armv6-alpine-linux-muslgnueabihf-",
            "CC": "armv6-alpine-linux-muslgnueabihf-gcc"}
-    cmd = ["CARCH=armhf", "CROSS_COMPILE=armv6-alpine-linux-muslgnueabihf-",
+    cmd = ["CARCH=armhf", sudo_apk, "CROSS_COMPILE=armv6-alpine-linux-muslgnueabihf-",
            "CC=armv6-alpine-linux-muslgnueabihf-gcc", "abuild", "-d"]
     assert func(args, apkbuild, "armhf", cross="native") == (output, cmd, env)
 


### PR DESCRIPTION
### Changes
Disabling the progress bars in abuild works just like Alpine does it in
their Travis CI script: Exporting `SUDO_APK` as
"abuild-apk --no-progress" instead of "abuild-apk".

test_check_checksums.py: Run "pmbootstrap build_init" before building
any packages, so it is a bit less verbose (downloading the APKINDEX
files etc.). Later we run the build init code again (because we use
--strict while building the packages), but then the APKINDEX files
are already present. So overall the log is a bit shorter before the
building starts. (It is still logged to the logfile, which gets
printed on error anyway.)

### Travis output
* [before](https://travis-ci.org/postmarketOS/pmbootstrap/builds/338039139#L700) (scroll down until you see the `apk` progress bars, which really mess up the output)
* [after](https://travis-ci.org/postmarketOS/pmbootstrap/builds/338702606#L706)