### PR TITLE
Rudimentary ZSH autocompletion helper

### DIFF
--- a/helpers/pmbootstrap-autocompletion.zsh
+++ b/helpers/pmbootstrap-autocompletion.zsh
@@ -1,38 +1,39 @@
 #!zsh
-#	Installation: 
+# Installation:
 #
-#	Copy this file to ~/.zsh/ (create it, if it doesn't exist, or put it 
-#	somewhere that makes sense to you) Then, insert the following line 
-#	in your ~/.zshrc (making sure to use the right folder name, if changed):
+# Copy this file to ~/.zsh/ (create it, if it doesn't exist, or put it
+# somewhere that makes sense to you). Then, insert the following line
+# in your ~/.zshrc (making sure to use the right folder name, if changed):
 #
-#		source ~/.zsh/pmbootstrap-auto-completion.zsh
+#	source ~/.zsh/pmbootstrap-auto-completion.zsh
 #
-#	Then, set the variable PMBOOTSTRAP_DIR to your `pmbootstrap` root.
-#	Example:
+# Then, set the variable PMBOOTSTRAP_DIR to your `pmbootstrap` root.
+# Example:
 #
-#		PMBOOTSTRAP_DIR=/home/axel/Git/pmbootstrap
-#	
-#	This file is VERY incomplete, and should really only be trusted to
-#	autocomplete directory names at this time.
+#	PMBOOTSTRAP_DIR=/home/axel/Git/pmbootstrap
+#
+# This file is rudimentary, pmbootstrap actions and packages are autocompleted
+# so far. Further ideas for improvements are here:
+# <https://github.com/postmarketOS/pmbootstrap/pull/1232>
 
 PMBOOTSTRAP_DIR=
 
-_pmbootstrap_commands () 
+_pmbootstrap_commands()
 {
-	grep '^def ' $PMBOOTSTRAP_DIR/pmb/helpers/frontend.py | cut -d ' ' -f 2 | cut -d '(' -f 1 | grep -v '^_'
+	grep '^def ' $PMBOOTSTRAP_DIR/pmb/helpers/frontend.py | cut -d ' ' -f 2 \
+		| cut -d '(' -f 1 | grep -v '^_'
 }
 
-_pmbootstrap_targets ()
+_pmbootstrap_targets()
 {
 	case $1 in
-		checksum|aportgen|build)
-			find $PMBOOTSTRAP_DIR/aports/ -mindepth 2 -type d -printf  '%f\n' | sed "s|$PMBOOTSTRAP_DIR/aports/||g"
+		build|checksum|pkgrel_bump)
+			find $PMBOOTSTRAP_DIR/aports/ -mindepth 2 -maxdepth 2 -type d \
+				-printf '%f\n' | sed "s|$PMBOOTSTRAP_DIR/aports/||g"
 			;;
-		kconfig_check)
-			ls -1 $PMBOOTSTRAP_DIR/aports/device/
-			;;
-		menuconfig)
-			ls -1 $PMBOOTSTRAP_DIR/aports/device/ | grep linux- | sed 's/linux-//g'
+		kconfig_check|menuconfig)
+			ls -1 $PMBOOTSTRAP_DIR/aports/*/ | grep linux- \
+				| sed 's/linux-//g'
 			;;
 		flasher)
 			echo flash_kernel flash_system
@@ -40,7 +41,7 @@ _pmbootstrap_targets ()
 	esac
 }
 
-_pmbootstrap ()
+_pmbootstrap()
 {
 	local curcontext="$curcontext" state line
 	typeset -A opt_args
@@ -48,7 +49,7 @@ _pmbootstrap ()
 	_arguments -C \
 		'1: :->command'\
 		'2: :->target'
-		
+
 		case $state in
 			command)
 				compadd `_pmbootstrap_commands`
@@ -59,6 +60,6 @@ _pmbootstrap ()
 		esac
 }
 
-if [ -d "$PMBOOTSTRAP_DIR" ] && [ -f $PMBOOTSTRAP_DIR/pmbootstrap.py ]; then
+if [ -f $PMBOOTSTRAP_DIR/pmbootstrap.py ]; then
 	compdef _pmbootstrap pmbootstrap
 fi

--- a/helpers/pmbootstrap-autocompletion.zsh
+++ b/helpers/pmbootstrap-autocompletion.zsh
@@ -35,16 +35,16 @@ _pmbootstrap ()
         '1: :->command'\
         '2: :->target'
     
-    if [ -f $PWD/pmbootstrap.py ]; then #We must be in the pmbootstrap dir
         case $state in
             command)
                 compadd `_pmbootstrap_commands`
                 ;;
             target)
-                compadd `_pmbootstrap_targets $line[1]`
+                if [ -f $PWD/pmbootstrap.py ]; then #We must be in the pmbootstrap dir
+                    compadd `_pmbootstrap_targets $line[1]`
+                fi
                 ;;
         esac
-    fi
 }
 
 compdef _pmbootstrap pmbootstrap

--- a/helpers/pmbootstrap-autocompletion.zsh
+++ b/helpers/pmbootstrap-autocompletion.zsh
@@ -1,0 +1,50 @@
+#!zsh
+# Installation: 
+#   Copy this file to ~/
+#   Insert the following line near the end of your ~/.zshrc:
+#
+#       source ~/pmbootstrap-auto-completion.zsh
+# 
+# This file is VERY incomplete, and should really only be trusted to
+# autocomplete aports/ directory names.
+
+
+_pmbootstrap_commands() 
+{
+    pmbootstrap -h | awk 'c&&!--c;/action:/{c=1}' | sed -e 's/{//g;s/}//g;s/,/ /g'
+}
+
+_pmbootstrap_targets()
+{
+    case $1 in
+        menuconfig|checksum|aportgen|build|kconfig_check)
+            \ls -l $PWD/aports/device/
+            ;;
+        flasher)
+            \echo flash_kernel flash_system
+            ;;
+    esac
+}
+
+_pmbootstrap ()
+{
+	local curcontext="$curcontext" state line
+	typeset -A opt_args
+
+    _arguments -C \
+        '1: :->command'\
+        '2: :->target'
+    
+    if [ -f $PWD/pmbootstrap.py ]; then #We must be in the pmbootstrap dir
+        case $state in
+            command)
+                compadd `_pmbootstrap_commands`
+                ;;
+            target)
+                compadd `_pmbootstrap_targets $line[1]`
+                ;;
+        esac
+    fi
+}
+
+compdef _pmbootstrap pmbootstrap

--- a/helpers/pmbootstrap-autocompletion.zsh
+++ b/helpers/pmbootstrap-autocompletion.zsh
@@ -18,7 +18,7 @@ _pmbootstrap_targets()
 {
     case $1 in
         menuconfig|checksum|aportgen|build|kconfig_check)
-            \ls -l $PWD/aports/device/
+            \ls -1 $PWD/aports/device/
             ;;
         flasher)
             \echo flash_kernel flash_system

--- a/helpers/pmbootstrap-autocompletion.zsh
+++ b/helpers/pmbootstrap-autocompletion.zsh
@@ -50,14 +50,14 @@ _pmbootstrap()
 		'1: :->command'\
 		'2: :->target'
 
-		case $state in
-			command)
-				compadd `_pmbootstrap_commands`
-				;;
-			target)
-				compadd `_pmbootstrap_targets $line[1]`
-				;;
-		esac
+	case $state in
+		command)
+			compadd `_pmbootstrap_commands`
+			;;
+		target)
+			compadd `_pmbootstrap_targets $line[1]`
+			;;
+	esac
 }
 
 if [ -f $PMBOOTSTRAP_DIR/pmbootstrap.py ]; then


### PR DESCRIPTION
For our users with ZSH, I wrote a (rather barebones) autocompletion script that will autocomplete `pmbootstrap` commands.

`pmbootstrap [tab]` will allow autocompletion selection of all the actions reported by `pmbootstrap -h`:

![selection_187](https://user-images.githubusercontent.com/2779682/36293090-b53bc0ee-12a4-11e8-8524-eca6438f17b1.png)

Then, the directories in `aports/device/` will be autocompletions as a second argument, but only if the user enters menuconfig, checksum, aportgen, build, or kconfig_check:

![selection_189](https://user-images.githubusercontent.com/2779682/36293096-bd9d67ec-12a4-11e8-81d5-0dcb59473e50.png)

Lastly, `pmbootstrap flasher` will currently suggest `flash_kernel` and `flash_system`:

![selection_190](https://user-images.githubusercontent.com/2779682/36293103-cb63a1c0-12a4-11e8-807a-9b7462169e87.png)

There is still a TON of stuff that `pmbootstrap` does that isn't covered in the script, and ~it~ target device/kernel completion currently only works while $PWD is the pmbootstrap directory, but it's a start. Since it's zsh-only, it's not `ash` as the contribution guidelines mention.

I also wasn't sure where to put it, so I went with `/helpers`, because it's not part of the main code in `/pmb`, and none of the other directories seemed appropriate either.