### PR TITLE
Check kernel config options based on the architecture

### DIFF
--- a/pmb/config/__init__.py
+++ b/pmb/config/__init__.py
@@ -158,16 +158,20 @@ build_cross_native = ["linux-*", "arch-bin-masquerade"]
 
 # Necessary kernel config options
 necessary_kconfig_options = {
-    "ANDROID_PARANOID_NETWORK": False,
-    "DEVTMPFS": True,
-    "DEVTMPFS_MOUNT": False,
-    "DM_CRYPT": True,
-    "EXT4_FS": True,
-    "PFT": False,
-    "SYSVIPC": True,
-    "VT": True
+    "all": {
+        "ANDROID_PARANOID_NETWORK": False,
+        "DEVTMPFS": True,
+        "DEVTMPFS_MOUNT": False,
+        "DM_CRYPT": True,
+        "EXT4_FS": True,
+        "PFT": False,
+        "SYSVIPC": True,
+        "VT": True
+    },
+    "armhf x86": {
+        "LBDAF": True
+    }
 }
-
 
 #
 # PARSE

--- a/pmb/parse/kconfig.py
+++ b/pmb/parse/kconfig.py
@@ -23,6 +23,7 @@ import os
 
 import pmb.build
 import pmb.config
+import pmb.parse
 
 
 def is_set(config, option):
@@ -58,25 +59,36 @@ def check(args, pkgname, details=False):
         # Loop trough necessary config options, and print a warning,
         # if any is missing
         path = "linux-" + flavor + "/" + os.path.basename(config_path)
-        for key, value in pmb.config.necessary_kconfig_options.items():
-            if value not in [True, False]:
-                raise RuntimeError("kconfig check code can only handle"
+        apkbuild = pmb.parse.apkbuild(args, aport + "/APKBUILD")
+        for archs, options in pmb.config.necessary_kconfig_options.items():
+            if archs != "all":
+                # Split and check if the device's architecture architecture has special config
+                # options. If option does not contain the architecture of the device
+                # kernel, then just skip the option.
+                # TODO: Should the device APKBUILDs support multiple architectures?
+                architectures = archs.split(" ")
+                if not apkbuild["arch"][0] in architectures:
+                    continue
+
+            for option, option_value in options.items():
+                if option_value not in [True, False]:
+                    raise RuntimeError("kconfig check code can only handle"
                                    " True/False right now, given value '" +
-                                   str(value) + "' is not supported. If you"
+                                   str(option_value) + "' is not supported. If you"
                                    " need this, please open an issue.")
-            if value != is_set(config, key):
-                ret = False
-                if details:
-                    should = "should" if value else "should *not*"
-                    link = ("https://wiki.postmarketos.org/wiki/"
-                            "Kernel_configuration#CONFIG_" + key)
-                    logging.info("WARNING: " + path + ": CONFIG_" + key + " " +
-                                 should + " be set. See <" + link +
+                if option_value != is_set(config, option):
+                    ret = False
+                    if details:
+                        should = "should" if option_value else "should *not*"
+                        link = ("https://wiki.postmarketos.org/wiki/"
+                                "Kernel_configuration#CONFIG_" + key)
+                        logging.info("WARNING: " + path + ": CONFIG_" + option + " " +
+                                should + " be set. See <" + link +
                                  "> for details.")
-                else:
-                    logging.warning("WARNING: " + path + " isn't configured"
+                    else:
+                        logging.warning("WARNING: " + path + " isn't configured"
                                     " properly for postmarketOS, run"
                                     " 'pmbootstrap kconfig_check' for"
                                     " details!")
-                    break
+                        break
     return ret

--- a/pmb/parse/kconfig.py
+++ b/pmb/parse/kconfig.py
@@ -56,18 +56,20 @@ def check(args, pkgname, details=False):
         with open(config_path) as handle:
             config = handle.read()
 
+        # The architecture of the config is in the name, so it just needs to be
+        # extracted
+        config_arch = os.path.basename(config_path).split(".")[1]
+
         # Loop trough necessary config options, and print a warning,
         # if any is missing
         path = "linux-" + flavor + "/" + os.path.basename(config_path)
-        apkbuild = pmb.parse.apkbuild(args, aport + "/APKBUILD")
         for archs, options in pmb.config.necessary_kconfig_options.items():
             if archs != "all":
                 # Split and check if the device's architecture architecture has special config
                 # options. If option does not contain the architecture of the device
                 # kernel, then just skip the option.
-                # TODO: Should the device APKBUILDs support multiple architectures?
                 architectures = archs.split(" ")
-                if not apkbuild["arch"][0] in architectures:
+                if config_arch not in architectures:
                     continue
 
             for option, option_value in options.items():

--- a/pmb/parse/kconfig.py
+++ b/pmb/parse/kconfig.py
@@ -73,22 +73,22 @@ def check(args, pkgname, details=False):
             for option, option_value in options.items():
                 if option_value not in [True, False]:
                     raise RuntimeError("kconfig check code can only handle"
-                                   " True/False right now, given value '" +
-                                   str(option_value) + "' is not supported. If you"
-                                   " need this, please open an issue.")
+                                       " True/False right now, given value '" +
+                                       str(option_value) + "' is not supported. If you"
+                                       " need this, please open an issue.")
                 if option_value != is_set(config, option):
                     ret = False
                     if details:
                         should = "should" if option_value else "should *not*"
                         link = ("https://wiki.postmarketos.org/wiki/"
-                                "Kernel_configuration#CONFIG_" + key)
+                                "Kernel_configuration#CONFIG_" + option)
                         logging.info("WARNING: " + path + ": CONFIG_" + option + " " +
-                                should + " be set. See <" + link +
-                                 "> for details.")
+                                     should + " be set. See <" + link +
+                                     "> for details.")
                     else:
                         logging.warning("WARNING: " + path + " isn't configured"
-                                    " properly for postmarketOS, run"
-                                    " 'pmbootstrap kconfig_check' for"
-                                    " details!")
+                                        " properly for postmarketOS, run"
+                                        " 'pmbootstrap kconfig_check' for"
+                                        " details!")
                         break
     return ret


### PR DESCRIPTION
Do not merge (yet).

This PR is supposed to solve #1218, which allows pmbootstrap to decide on which kernel config
options are to be checked, based on the `arch` option in the `APKBUILD` of a `linux-<device>` package.
The options under the `all` key are applied to every architecture. Using a key like `"armhf x86"` would result in the kernel config options being checked for both armhf and x86.