### PR TITLE
Add a check for binfmt_misc

### DIFF
--- a/pmb/__init__.py
+++ b/pmb/__init__.py
@@ -39,6 +39,7 @@ def main():
     try:
         # Sanity checks
         other.check_grsec(args)
+        other.check_binfmt_misc(args)
         if not args.as_root and os.geteuid() == 0:
             raise RuntimeError("Do not run pmbootstrap as root!")
 

--- a/pmb/__init__.py
+++ b/pmb/__init__.py
@@ -39,7 +39,6 @@ def main():
     try:
         # Sanity checks
         other.check_grsec(args)
-        other.check_binfmt_misc(args)
         if not args.as_root and os.geteuid() == 0:
             raise RuntimeError("Do not run pmbootstrap as root!")
 

--- a/pmb/chroot/binfmt.py
+++ b/pmb/chroot/binfmt.py
@@ -20,6 +20,7 @@ import os
 import logging
 
 import pmb.helpers.run
+import pmb.helpers.other
 import pmb.parse
 import pmb.parse.arch
 
@@ -35,6 +36,7 @@ def register(args, arch):
     arch_debian = pmb.parse.arch.alpine_to_debian(arch)
     if is_registered(arch_debian):
         return
+    pmb.helpers.other.check_binfmt_misc(args)
     pmb.chroot.apk.install(args, ["qemu-user-static-repack",
                                   "qemu-user-static-repack-binfmt"])
     info = pmb.parse.binfmt_info(args, arch_debian)

--- a/pmb/helpers/other.py
+++ b/pmb/helpers/other.py
@@ -71,12 +71,11 @@ def check_binfmt_misc(args):
     if os.path.exists(path):
         return
 
-    link = "https://wiki.postmarketos.org/wiki/Troubleshooting#sh:_can.27t_create_.2Fproc.2Fsys.2Ffs.2Fbinfmt_misc.2Fregister:_nonexistent_directory"
+    link = "https://postmarketos.org/binfmt_misc"
     raise RuntimeError("It appears that your system has not loaded the"
-                       " module 'binfmt_misc'. This can lead to"
-                       " problems later on, so it would be best"
-                       " if you followed the troubleshooting"
-                       " steps in the Wiki."
+                       " module 'binfmt_misc'. This is required to run"
+                       " foreign architecture programs with QEMU (eg. "
+                       " armhf on x86_64):"
                        " \nSee <" + link + ">")
 
 

--- a/pmb/helpers/other.py
+++ b/pmb/helpers/other.py
@@ -74,9 +74,8 @@ def check_binfmt_misc(args):
     link = "https://postmarketos.org/binfmt_misc"
     raise RuntimeError("It appears that your system has not loaded the"
                        " module 'binfmt_misc'. This is required to run"
-                       " foreign architecture programs with QEMU (eg. "
-                       " armhf on x86_64):"
-                       " \nSee <" + link + ">")
+                       " foreign architecture programs with QEMU (eg."
+                       " armhf on x86_64):\n See: <" + link + ">")
 
 
 def migrate_success(args):

--- a/pmb/helpers/other.py
+++ b/pmb/helpers/other.py
@@ -61,6 +61,25 @@ def check_grsec(args):
                        " more details: <" + link + ">")
 
 
+def check_binfmt_misc(args):
+    """
+    Check if the 'binfmt_misc' module is loaded by checking, if
+    /proc/sys/fs/binfmt_misc/ exists. If it exists, then do nothing.
+    Otherwise, raise an exception pointing to user to the Wiki.
+    """
+    path = "/proc/sys/fs/binfmt_misc/"
+    if os.path.exists(path):
+        return
+
+    link = "https://wiki.postmarketos.org/wiki/Troubleshooting#sh:_can.27t_create_.2Fproc.2Fsys.2Ffs.2Fbinfmt_misc.2Fregister:_nonexistent_directory"
+    raise RuntimeError("It appears that your system has not loaded the"
+                       " module 'binfmt_misc'. This can lead to"
+                       " problems later on, so it would be best"
+                       " if you followed the troubleshooting"
+                       " steps in the Wiki."
+                       " \nSee <" + link + ">")
+
+
 def migrate_success(args):
     logging.info("Migration done")
     with open(args.work + "/version", "w") as handle:


### PR DESCRIPTION
Do not merge (yet).

To solve #1223, I added a check at the start of pmbootstrap, that looks for `/proc/sys/fs/binfmt_misc` and prints a message to the user pointing him to the Wiki, if the path does not exist.