### PR TITLE
Add a maximum-attention hook to help with debugging boot issues

### DIFF
--- a/aports/main/postmarketos-mkinitfs-hook-maximum-attention/00-maximum-attention.sh
+++ b/aports/main/postmarketos-mkinitfs-hook-maximum-attention/00-maximum-attention.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+. ./init_functions.sh
+
+BLINK_INTERVAL=2 # seconds
+VIBRATION_DURATION=400 #ms
+VIBRATION_INTERVAL=2 #s
+
+find_leds() {
+	find /sys -name "max_brightness" | xargs -I{} dirname {}
+}
+
+find_vibrator() {
+	echo /sys/class/timed_output/vibrator
+}
+
+
+# blink_leds takes a list of LEDs as parameters,
+# it iterates over every LED, and changes their value,
+# alternating between max_brightness and 0 every BLINK_INTERVAL
+blink_leds() {
+	state=false # false = off, true=on
+	while true; do
+		for led in $@; do
+			if [ "$state" = true ]; then
+				cat $led/max_brightness > $led/brightness
+			else
+				echo 0 > $led/brightness
+			fi
+			echo blinking LED: $led
+		done
+		sleep ${BLINK_INTERVAL}s
+		if [ "$state" = true ]; then
+			state=false
+		else
+			state=true
+		fi
+	done
+}
+
+# vibrate_loop vibrates each VIBRATION_INTERVAL for VIBRATION_DURATION
+# it takes a timed_device path to the vibrator as $1
+vibrate_loop() {
+	if [ ! -f $1/enable ]; then
+		return;
+	fi
+
+	while true; do
+		echo $VIBRATION_DURATION > $1/enable
+		sleep ${VIBRATION_INTERVAL}s
+	done
+}
+
+blink_leds $(find_leds) &
+vibrate_loop $(find_vibrator) &
+
+loop_forever

--- a/aports/main/postmarketos-mkinitfs-hook-maximum-attention/APKBUILD
+++ b/aports/main/postmarketos-mkinitfs-hook-maximum-attention/APKBUILD
@@ -1,0 +1,16 @@
+pkgname=postmarketos-mkinitfs-hook-maximum-attention
+pkgver=0.1.0
+pkgrel=0
+pkgdesc="Script to activate all user-visible outputs from the initramfs (to confirm working kernel, for debugging only)"
+url="https://github.com/postmarketOS"
+depends="postmarketos-mkinitfs"
+source="00-maximum-attention.sh"
+arch="noarch"
+license="GPL2"
+
+package() {
+	mkdir -p "$pkgdir"/etc/postmarketos-mkinitfs/hooks/
+	install -Dm644 "$srcdir"/00-maximum-attention.sh \
+		"$pkgdir"/etc/postmarketos-mkinitfs/hooks/
+}
+sha512sums="c29cc41649c284c0ec8201715cd9452f838801a22ea6c2a312ea87a58c61c1caa05a3b1ff33ce4a4d680a95e79fb10108308b72173f1fa97bac5cefde7ab30ee  00-maximum-attention.sh"


### PR DESCRIPTION
The hook flashes every LED it can find, as well as the vibration motor.
More paths are probably necessary to support more devices and kernels.

This is intended as a first approach to #1217
Also somewhat related to #88 

The name comes from ollieparanoid on Matrix, IIRC.