### PR TITLE
Always prefer native/device arch when building

### DIFF
--- a/pmb/build/autodetect.py
+++ b/pmb/build/autodetect.py
@@ -53,9 +53,11 @@ def arch(args, pkgname):
     Find a good default in case the user did not specify for which architecture
     a package should be built.
 
-    :returns: native architecture (x86_64 in most cases) when the APKBUILD has
-              "noarch" or "all". Otherwise the first architecture in the
-              APKBUILD.
+    :returns: arch string like "x86_64" or "armhf". Preferred order, depending
+              on what is supported by the APKBUILD:
+              * native arch
+              * device arch
+              * first arch in the APKBUILD
     """
     aport = pmb.build.find_aport(args, pkgname)
     ret = arch_from_deviceinfo(args, pkgname, aport)
@@ -63,8 +65,14 @@ def arch(args, pkgname):
         return ret
 
     apkbuild = pmb.parse.apkbuild(args, aport + "/APKBUILD")
-    if "noarch" in apkbuild["arch"] or "all" in apkbuild["arch"]:
+    arches = apkbuild["arch"]
+    if "noarch" in arches or "all" in arches or args.arch_native in arches:
         return args.arch_native
+
+    arch_device = args.deviceinfo["arch"]
+    if arch_device in arches:
+        return arch_device
+
     return apkbuild["arch"][0]
 
 


### PR DESCRIPTION
In case the user does not specify for which arch packages should be
built with `pmbootstrap build`, we detect it automatically.

Previous logic was, that if the APKBUILD's arch is "all" or "noarch",
then prefer the native arch, and otherwise use the first one in the
list of available arches.

New behavior is, that we also check if the list of possible arches
contains the native arch (and if that fails, the device arch). If that
is the case, we return the native/device arch instead of the first one
in the list.

### Use case

The arch from `gcc-armhf` and similar packages (as generated by
`pmbootstrap aportgen`) used to be "all", but is nowadays a specific
list of arches. This means, that after updating the `gcc-armhf` and
`gcc-aarch64` packages, and calling `pmbootstrap build gcc-armhf`,
it will try to build `gcc-armhf` for `aarch64` instead of the native
architecture, because that is the first one listed.
And since compiling to `aarch64` requires `gcc-aarch64`, it will build
that for the native architecture first.

So you're asking for `gcc-armhf` and it compiles `gcc-aarch64`, which
is very confusing (see #1272).