### PR TITLE
Skip virtual packages when parsing APKINDEX

### DIFF
--- a/pmb/parse/apkindex.py
+++ b/pmb/parse/apkindex.py
@@ -37,9 +37,16 @@ def parse_next_block(args, path, lines, start):
     :returns: a dictionary with the following structure:
               { "arch": "noarch",
                 "depends": ["busybox-extras", "lddtree", ... ],
+                "origin": "postmarketos-mkinitfs",
                 "pkgname": "postmarketos-mkinitfs",
                 "provides": ["mkinitfs=0.0.1"],
+                "timestamp": "1500000000",
                 "version": "0.0.4-r10" }
+              NOTE: "depends" is not set for packages without any dependencies,
+                    e.g. musl.
+              NOTE: "timestamp" and "origin" are not set for virtual packages
+                    (#1273). We use that information to skip these virtual
+                    packages in parse().
     :returns: None, when there are no more blocks
     """
 
@@ -77,7 +84,7 @@ def parse_next_block(args, path, lines, start):
     # Format and return the block
     if end_of_block_found:
         # Check for required keys
-        for key in ["pkgname", "version", "timestamp"]:
+        for key in ["arch", "pkgname", "version"]:
             if key not in ret:
                 raise RuntimeError("Missing required key '" + key +
                                    "' in block " + str(ret) + ", file: " + path)
@@ -206,6 +213,12 @@ def parse(args, path, multiple_providers=True):
         block = parse_next_block(args, path, lines, start)
         if not block:
             break
+
+        # Skip virtual packages
+        if "timestamp" not in block:
+            logging.verbose("Skipped virtual package " + str(block) + " in"
+                            " file: " + path)
+            continue
 
         # Add the next package and all aliases
         parse_add_block(ret, block, None, multiple_providers)

--- a/test/testdata/apkindex/virtual_package
+++ b/test/testdata/apkindex/virtual_package
@@ -1,0 +1,31 @@
+C:Q1XaZzCVZ9mvH8djPyEb5aUYhG3r4=
+P:hello-world
+V:2-r0
+A:x86_64
+S:2897
+I:20480
+T:hello world program to be built in the testsuite
+U:https://en.wikipedia.org/wiki/%22Hello,_World!%22_program
+L:MIT
+o:hello-world
+t:1500000000
+c:
+D:so:libc.musl-x86_64.so.1
+p:cmd:hello-world
+F:usr
+F:usr/bin
+R:hello-world
+a:0:0:755
+Z:Q1ZjTpsnMchSsSwEPB1cTjihYuJvo=
+
+C:Q127l1Ui9vzedbeR3BMelZnSa4pwY=
+P:.pmbootstrap
+V:0
+A:noarch
+S:0
+I:0
+T:virtual meta package
+U:
+L:
+D:hello-world
+


### PR DESCRIPTION
Since PR #1247 we are using the virtual package `.pmbootstrap` to mark
packages as not explcitly installed. In case `pmbootstrap` doesn't
finish the installation because of a bug, the `.pmbootstrap` virtual
package may not get uninstalled.

As virtual packages don't have the "timestamp" attribute set in the
package database (which indicates when the package was built), the
APKINDEX parser fails to parse them.

Changes:
* pmb.parse.apkindex.parse_next_block(): don't require the "timestamp"
  attribute to be set (but the arch attribute instead, which is always
  present)
* pmb.parse.apkindex.parse(): when a block does not have a `timestamp`
  attribute, skip it, because it must be a virtual package.
* add test cases for both functions with a package database that
  contains a virtual package.

Fixes #1273.