### PR TITLE
Fix build --src for foreign-arch chroots

### DIFF
--- a/pmb/build/_package.py
+++ b/pmb/build/_package.py
@@ -257,7 +257,7 @@ def override_source(args, apkbuild, pkgver, src, suffix="native"):
     append_path = "/tmp/APKBUILD.append"
     append_path_outside = args.work + "/chroot_" + suffix + append_path
     if os.path.exists(append_path_outside):
-        pmb.chroot.root(args, ["rm", append_path])
+        pmb.chroot.root(args, ["rm", append_path], suffix)
 
     # Add src path to pkgdesc, cut it off after max length
     pkgdesc = ("[" + src + "] " + apkbuild["pkgdesc"])[:127]
@@ -298,14 +298,14 @@ def override_source(args, apkbuild, pkgver, src, suffix="native"):
     with open(append_path_outside, "w", encoding="utf-8") as handle:
         for line in append.split("\n"):
             handle.write(line[13:].replace(" " * 4, "\t") + "\n")
-    pmb.chroot.user(args, ["cat", append_path])
+    pmb.chroot.user(args, ["cat", append_path], suffix)
 
     # Append it to the APKBUILD
     apkbuild_path = "/home/pmos/build/APKBUILD"
     shell_cmd = ("cat " + apkbuild_path + " " + append_path + " > " +
                  append_path + "_")
-    pmb.chroot.user(args, ["sh", "-c", shlex.quote(shell_cmd)])
-    pmb.chroot.user(args, ["mv", append_path + "_", apkbuild_path])
+    pmb.chroot.user(args, ["sh", "-c", shlex.quote(shell_cmd)], suffix)
+    pmb.chroot.user(args, ["mv", append_path + "_", apkbuild_path], suffix)
 
 
 def run_abuild(args, apkbuild, arch, strict=False, force=False, cross=None,

--- a/test/test_build_package.py
+++ b/test/test_build_package.py
@@ -363,23 +363,24 @@ def test_build_local_source_high_level(args, tmpdir):
     pmb.helpers.run.root(args, ["chown", "root:root", unreadable])
     pmb.helpers.run.root(args, ["chmod", "500", unreadable])
 
-    # Delete all hello-world --src packages
-    pattern = (args.work + "/packages/" + args.arch_native +
-               "/hello-world-*_p*.apk")
-    for path in glob.glob(pattern):
-        pmb.helpers.run.root(args, ["rm", path])
-    assert len(glob.glob(pattern)) == 0
+    # Test native arch and foreign arch chroot
+    for arch in [args.arch_native, "armhf"]:
+        # Delete all hello-world --src packages
+        pattern = args.work + "/packages/" + arch + "/hello-world-*_p*.apk"
+        for path in glob.glob(pattern):
+            pmb.helpers.run.root(args, ["rm", path])
+        assert len(glob.glob(pattern)) == 0
 
-    # Build hello-world --src package
-    pmb.helpers.run.user(args, [pmb.config.pmb_src + "/pmbootstrap.py",
-                                "--aports", aports, "build", "--src", src,
-                                "hello-world"])
+        # Build hello-world --src package
+        pmb.helpers.run.user(args, [pmb.config.pmb_src + "/pmbootstrap.py",
+                                    "--aports", aports, "build", "--src", src,
+                                    "hello-world", "--arch", arch])
 
-    # Verify that the package has been built
-    paths = glob.glob(pattern)
-    assert len(paths) == 1
+        # Verify that the package has been built and delete it
+        paths = glob.glob(pattern)
+        assert len(paths) == 1
+        pmb.helpers.run.root(args, ["rm", paths[0]])
 
-    # Clean up: delete package and tempfolder, update index
-    pmb.helpers.run.root(args, ["rm", paths[0]])
+    # Clean up: update index, delete temp folder
     pmb.build.index_repo(args, args.arch_native)
     pmb.helpers.run.root(args, ["rm", "-r", tmpdir])


### PR DESCRIPTION
The `suffix` argument was not specified in chroot commands executed in
`pmb.build._package.override_source()`. Because of that, it was not
possible to use "build --src" when compiling in a non-native chroot,
for example:

```
$ pmbootstrap build hello-world --arch=armhf --src=~/code/pmbootstrap/aports/main/hello-world
...
(native) % rm /tmp/APKBUILD.append
rm: can't remove '/tmp/APKBUILD.append': No such file or directory
```

Thanks to @scintill for reporting this in https://github.com/postmarketOS/pmbootstrap/pull/1210#issuecomment-369827265!

@scintill: do you want to test and review this?