### PR TITLE
Depend on libepoxy-dev from kdeclarative

### DIFF
--- a/aports/kde/kdeclarative/APKBUILD
+++ b/aports/kde/kdeclarative/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kdeclarative
 pkgver=5.43.0
-pkgrel=0
+pkgrel=1
 pkgdesc='Provides integration of QML and KDE Frameworks'
 arch="all"
 url='https://community.kde.org/Frameworks'
@@ -11,7 +11,7 @@ depends=""
 depends_dev="kpackage-dev kconfig-dev kiconthemes-dev kglobalaccel-dev kwindowsystem-dev
 			 kio-dev kguiaddons-dev qt5-qtdeclarative-dev ki18n-dev kcoreaddons-dev kservice-dev
 			 kbookmarks-dev kwidgetsaddons-dev kcompletion-dev kitemviews-dev kjobwidgets-dev
-			 solid-dev kxmlgui-dev kconfigwidgets-dev kauth-dev kcodecs-dev"
+			 solid-dev kxmlgui-dev kconfigwidgets-dev kauth-dev kcodecs-dev libepoxy-dev"
 makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
 source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"


### PR DESCRIPTION
Fixes the https://phabricator.kde.org/T7808 at least in qemu, please verify.