### PR TITLE
Fix building packages by provides name

### DIFF
--- a/pmb/build/other.py
+++ b/pmb/build/other.py
@@ -58,7 +58,8 @@ def find_aport(args, package, must_exist=True):
             # Search in subpackages
             for path_current in glob.glob(args.aports + "/*/*/APKBUILD"):
                 apkbuild = pmb.parse.apkbuild(args, path_current)
-                if package in apkbuild["subpackages"]:
+                if (package in apkbuild["subpackages"] or
+                        package in apkbuild["provides"]):
                     ret = os.path.dirname(path_current)
                     break
 

--- a/pmb/config/__init__.py
+++ b/pmb/config/__init__.py
@@ -191,6 +191,7 @@ apkbuild_attributes = {
     "pkgdesc": {"array": False},
     "pkgrel": {"array": False},
     "pkgver": {"array": False},
+    "provides": {"array": True},
     "subpackages": {"array": True},
 
     # cross-compilers

--- a/pmb/parse/bootimg.py
+++ b/pmb/parse/bootimg.py
@@ -27,7 +27,7 @@ def bootimg(args, path):
 
     logging.info("NOTE: You will be prompted for your sudo password, so we can set"
                  " up a chroot to extract and analyze your boot.img file")
-    pmb.chroot.apk.install(args, ["file", "mkbootimg"])
+    pmb.chroot.apk.install(args, ["file", "unpackbootimg"])
 
     temp_path = pmb.chroot.other.tempfolder(args, "/tmp/bootimg_parser")
     bootimg_path = args.work + "/chroot_native" + temp_path + "/boot.img"


### PR DESCRIPTION
Use case: `mkbootimg` provides the `unpackbootimg` package. When
running `pmb.chroot.apk.install(args,"unpackbootimg")`, it was not
able to properly build the package.

Reproducing the error:
```shell
sudo rm ~/.local/var/pmbootstrap/packages/x86_64/mkbootimg*
pmbootstrap index
pmbootstrap --mirror-pmOS="" chroot --add=unpackbootimg
```

Or alternatively (simpler but less illustrative):
```shell
pmbootstrap build unpackbootimg --force
```

Fixes #1220.