### PR TITLE
Make /home/pmos/build world-readable

### DIFF
--- a/pmb/build/other.py
+++ b/pmb/build/other.py
@@ -82,13 +82,13 @@ def copy_to_buildpath(args, package, suffix="native"):
     # Clean up folder
     build = args.work + "/chroot_" + suffix + "/home/pmos/build"
     if os.path.exists(build):
-        pmb.chroot.root(args, ["rm", "-rf", "/home/pmos/build"],
-                        suffix=suffix)
+        pmb.chroot.root(args, ["rm", "-rf", "/home/pmos/build"], suffix)
 
-    # Copy aport contents
+    # Copy aport and set permissions (#1298)
     pmb.helpers.run.root(args, ["cp", "-r", aport + "/", build])
-    pmb.chroot.root(args, ["chown", "-R", "pmos:pmos",
-                           "/home/pmos/build"], suffix=suffix)
+    pmb.chroot.root(args, ["chown", "-R", "pmos:pmos", "/home/pmos/build"],
+                    suffix)
+    pmb.chroot.user(args, ["chmod", "-R", "a+rX", "/home/pmos/build"], suffix)
 
 
 def is_necessary(args, arch, apkbuild, indexes=None):


### PR DESCRIPTION
When calculating checksums, we copy an aport folder to
`/home/pmos/build`, `chown` it to the `pmos` user, let `abuild`
calculate the checksums, and copy the `APKINDEX` back.

So far this only worked as long as the `aports/main/hello-world`
folder in this example is already world-readable. If it is not (e.g.
because the system had a different default umask), then the copying
back step will fail.

This commit makes the copied folder world readable to fix this.

Fixes #1298.
@V13Axel: if you have time, it would be nice if you could test and review the change :+1: