### PR TITLE
Mount tmpfs in chroot's /dev folders

### DIFF
--- a/pmb/chroot/init.py
+++ b/pmb/chroot/init.py
@@ -46,10 +46,7 @@ def copy_resolv_conf(args, suffix="native"):
 
 
 def create_device_nodes(args, suffix):
-    error = ("Failed to create nodes in the '" + suffix + "' chroot. Please"
-             " run 'pmbootstrap init' again and put your work folder on a"
-             " normal Linux filesystem. (No ntfs, fat, encfs or encfs"
-             " encrypted home folder, shared folder etc.)")
+    error = "Failed to create device nodes in the '" + suffix + "' chroot."
 
     # Folder sturcture
     chroot = args.work + "/chroot_" + suffix


### PR DESCRIPTION
Mount tmpfs inside the chroot's dev folder to make sure we can create device nodes, even if the filesystem of the work folder does not support it. Closes #1175.

@ethanrjones97 wrote in https://github.com/postmarketOS/pmbootstrap/issues/1175#issuecomment-371958793:
> I managed to port a device over with the patch applied, that seems to be a pretty good test :man_shrugging: 

Thanks, that is some solid testing indeed!

I'm also putting this up for review as usually. Would you or someone else take a look at the code before it gets merged?