### PR TITLE
Set the hostname as the device name

### DIFF
--- a/pmb/config/__init__.py
+++ b/pmb/config/__init__.py
@@ -45,8 +45,8 @@ apk_tools_static_min_version = "2.9.0-r0"
 work_version = "1"
 
 # Only save keys to the config file, which we ask for in 'pmbootstrap init'.
-config_keys = ["ccache_size", "device", "extra_packages", "jobs", "keymap",
-               "nonfree_firmware", "nonfree_userland",
+config_keys = ["ccache_size", "device", "extra_packages", "hostname", "jobs",
+               "keymap", "nonfree_firmware", "nonfree_userland",
                "qemu_native_mesa_driver", "timezone", "ui", "user", "work"]
 
 # Config file/commandline default values
@@ -62,6 +62,7 @@ defaults = {
     "config": os.path.expanduser("~") + "/.config/pmbootstrap.cfg",
     "device": "samsung-i9100",
     "extra_packages": "none",
+    "hostname": "",
     # A higher value is typically desired, but this can lead to VERY long open
     # times on slower devices due to host systems being MUCH faster than the
     # target device: <https://github.com/postmarketOS/pmbootstrap/issues/429>

--- a/pmb/config/init.py
+++ b/pmb/config/init.py
@@ -246,19 +246,25 @@ def ask_for_hostname(args, device):
         ret = pmb.helpers.cli.ask(args, "Device hostname (short form, e.g. 'foo')",
                                   None, device, True)
         # http://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names
-        # check length
+        # Check length
         if len(ret) > 63:
             logging.fatal("ERROR: Hostname '" + ret + "' is too long.")
             continue
-        # check that it only contains valid chars
+
+        # Check that it only contains valid chars
         if not re.match("^[0-9a-z-]*$", ret):
             logging.fatal("ERROR: Hostname must only contain letters (a-z),"
                           " digits (0-9) or minus signs (-)")
             continue
-        # check that doesn't begin or end with a minus sign
+
+        # Check that doesn't begin or end with a minus sign
         if ret[:1] == "-" or ret[-1:] == "-":
             logging.fatal("ERROR: Hostname must not begin or end with a minus sign")
             continue
+
+        # Don't store device name in user's config (gets replaced in install)
+        if ret == device:
+            return ""
         return ret
 
 

--- a/pmb/config/init.py
+++ b/pmb/config/init.py
@@ -241,10 +241,10 @@ def ask_for_build_options(args, cfg):
     cfg["pmbootstrap"]["ccache_size"] = answer
 
 
-def ask_for_hostname(args):
+def ask_for_hostname(args, device):
     while True:
         ret = pmb.helpers.cli.ask(args, "Device hostname (short form, e.g. 'foo')",
-                                  None, args.device, True)
+                                  None, device, True)
         # http://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names
         # check length
         if len(ret) > 63:
@@ -304,7 +304,7 @@ def frontend(args):
     cfg["pmbootstrap"]["timezone"] = ask_for_timezone(args)
 
     # Hostname
-    cfg["pmbootstrap"]["hostname"] = ask_for_hostname(args)
+    cfg["pmbootstrap"]["hostname"] = ask_for_hostname(args, device)
 
     # Save config
     pmb.config.save(args, cfg)

--- a/pmb/config/init.py
+++ b/pmb/config/init.py
@@ -244,7 +244,7 @@ def ask_for_build_options(args, cfg):
 def ask_for_hostname(args, device):
     while True:
         ret = pmb.helpers.cli.ask(args, "Device hostname (short form, e.g. 'foo')",
-                                  None, device, True)
+                                  None, (args.hostname or device), True)
         # http://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names
         # Check length
         if len(ret) > 63:

--- a/pmb/config/init.py
+++ b/pmb/config/init.py
@@ -19,7 +19,6 @@ along with pmbootstrap.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 import glob
 import os
-import re
 
 import pmb.config
 import pmb.helpers.cli
@@ -245,23 +244,8 @@ def ask_for_hostname(args, device):
     while True:
         ret = pmb.helpers.cli.ask(args, "Device hostname (short form, e.g. 'foo')",
                                   None, (args.hostname or device), True)
-        # http://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names
-        # Check length
-        if len(ret) > 63:
-            logging.fatal("ERROR: Hostname '" + ret + "' is too long.")
+        if not pmb.helpers.other.validate_hostname(ret):
             continue
-
-        # Check that it only contains valid chars
-        if not re.match("^[0-9a-z-]*$", ret):
-            logging.fatal("ERROR: Hostname must only contain letters (a-z),"
-                          " digits (0-9) or minus signs (-)")
-            continue
-
-        # Check that doesn't begin or end with a minus sign
-        if ret[:1] == "-" or ret[-1:] == "-":
-            logging.fatal("ERROR: Hostname must not begin or end with a minus sign")
-            continue
-
         # Don't store device name in user's config (gets replaced in install)
         if ret == device:
             return ""

--- a/pmb/helpers/other.py
+++ b/pmb/helpers/other.py
@@ -16,8 +16,9 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with pmbootstrap.  If not, see <http://www.gnu.org/licenses/>.
 """
-import os
 import logging
+import os
+import re
 import pmb.chroot
 import pmb.config
 import pmb.helpers.run
@@ -127,3 +128,26 @@ def migrate_work_folder(args):
                        " folder manually ('sudo rm -rf " + args.work +
                        "') and start over with 'pmbootstrap init'. All your"
                        " binary packages will be lost.")
+
+
+def validate_hostname(hostname):
+    """
+    Check whether the string is a valid hostname, according to
+    <http://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names>
+    """
+    # Check length
+    if len(hostname) > 63:
+        logging.fatal("ERROR: Hostname '" + hostname + "' is too long.")
+        return False
+
+    # Check that it only contains valid chars
+    if not re.match("^[0-9a-z-]*$", hostname):
+        logging.fatal("ERROR: Hostname must only contain letters (a-z),"
+                      " digits (0-9) or minus signs (-)")
+        return False
+
+    # Check that doesn't begin or end with a minus sign
+    if hostname[:1] == "-" or hostname[-1:] == "-":
+        logging.fatal("ERROR: Hostname must not begin or end with a minus sign")
+        return False
+    return True

--- a/pmb/install/_install.py
+++ b/pmb/install/_install.py
@@ -236,21 +236,12 @@ def setup_keymap(args):
 
 def setup_hostname(args):
     """
-    Set the hostname as the device name unless not modified already
+    Set the hostname and update localhost address on /etc/hosts
     """
     suffix = "rootfs_" + args.device
-
-    alpine_hostname = "localhost"
-    new_hostname = args.device
-    hostname = pmb.chroot.root(args, ["cat", "/etc/hostname"], suffix, return_stdout=True)
-    if hostname.strip() == alpine_hostname:
-        pmb.chroot.root(args, ["sh", "-c", "echo '" + new_hostname + "' > /etc/hostname"], suffix)
-
-    alpine_hosts = "127.0.0.1\tlocalhost localhost.localdomain"
-    new_hosts = "127.0.0.1\t" + args.device + " " + args.device + ".localdomain"
-    hosts = pmb.chroot.root(args, ["cat", "/etc/hosts"], suffix, return_stdout=True)
-    if hosts.strip() == alpine_hosts:
-        pmb.chroot.root(args, ["sh", "-c", "echo '" + new_hosts + "' > /etc/hosts"], suffix)
+    pmb.chroot.root(args, ["sh", "-c", "echo '" + args.hostname + "' > /etc/hostname"], suffix)
+    regex = "s/^127\.0\.0\.1.*/127.0.0.1\t" + args.hostname + " localhost.localdomain localhost/"
+    pmb.chroot.root(args, ["sed", "-i", "-e", regex, "/etc/hosts"], suffix)
 
 
 def install_system_image(args):

--- a/pmb/install/_install.py
+++ b/pmb/install/_install.py
@@ -245,6 +245,10 @@ def setup_hostname(args):
     if not hostname:
         hostname = args.device
 
+    if not pmb.helpers.other.validate_hostname(hostname):
+        raise RuntimeError("Hostname '" + hostname + "' is not valid, please"
+                           " run 'pmbootstrap init' to configure it.")
+
     # Update /etc/hosts
     suffix = "rootfs_" + args.device
     pmb.chroot.root(args, ["sh", "-c", "echo " + shlex.quote(hostname) +

--- a/pmb/install/_install.py
+++ b/pmb/install/_install.py
@@ -18,7 +18,9 @@ along with pmbootstrap.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
 import os
+import re
 import glob
+import shlex
 
 import pmb.chroot
 import pmb.chroot.apk
@@ -236,11 +238,19 @@ def setup_keymap(args):
 
 def setup_hostname(args):
     """
-    Set the hostname and update localhost address on /etc/hosts
+    Set the hostname and update localhost address in /etc/hosts
     """
+    # Default to device name
+    hostname = args.hostname
+    if not hostname:
+        hostname = args.device
+
+    # Update /etc/hosts
     suffix = "rootfs_" + args.device
-    pmb.chroot.root(args, ["sh", "-c", "echo '" + args.hostname + "' > /etc/hostname"], suffix)
-    regex = "s/^127\.0\.0\.1.*/127.0.0.1\t" + args.hostname + " localhost.localdomain localhost/"
+    pmb.chroot.root(args, ["sh", "-c", "echo " + shlex.quote(hostname) +
+                    " > /etc/hostname"], suffix)
+    regex = ("s/^127\.0\.0\.1.*/127.0.0.1\t" + re.escape(hostname) +
+             " localhost.localdomain localhost/")
     pmb.chroot.root(args, ["sed", "-i", "-e", regex, "/etc/hosts"], suffix)
 
 

--- a/test/test_questions.py
+++ b/test/test_questions.py
@@ -219,3 +219,28 @@ def test_questions_build_options(args, monkeypatch):
     func(args, cfg)
     assert cfg == {"pmbootstrap": {"jobs": "5",
                                    "ccache_size": "2G"}}
+
+
+def test_questions_hostname(args, monkeypatch):
+    func = pmb.config.init.ask_for_hostname
+    device = "test-device"
+
+    # Valid hostname
+    fake_answers(monkeypatch, ["valid"])
+    assert func(args, device) == "valid"
+
+    # Hostname too long ("aaaaa...")
+    fake_answers(monkeypatch, ["a" * 64, "a" * 63])
+    assert func(args, device) == "a" * 63
+
+    # Fail the regex
+    fake_answers(monkeypatch, ["$invalid", "valid"])
+    assert func(args, device) == "valid"
+
+    # Begins or ends with minus
+    fake_answers(monkeypatch, ["-invalid", "invalid-", "valid"])
+    assert func(args, device) == "valid"
+
+    # Device name: empty string
+    fake_answers(monkeypatch, [device])
+    assert func(args, device) == ""


### PR DESCRIPTION
During the `pmbootstrap install`, also set the hostname as the device name. Also update the `/etc/hosts` file to resolve the new hostname.

It will change it only if the actual files contains the default value specified by Alpine here: 
https://git.alpinelinux.org/cgit/aports/tree/main/alpine-baselayout/APKBUILD#n122

If future we may consider to prompt the user for the hostname, like almost every distribution installer does.

This also solves an issue with X11 not starting properly due the NetworkManager doing something with an hostname not set.
See here: https://bbs.archlinux.org/viewtopic.php?id=108695