### PR TITLE
Travis CI: folded output/default tracebacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,10 @@ install:
   - sudo apt install shellcheck qemu-system-x86
   - pip install flake8 pytest-cov python-coveralls
 script:
-  - test/static_code_analysis.sh
-  - yes "" | ./pmbootstrap.py init
-  - ./pmbootstrap.py kconfig_check
-  - test/check_checksums.py --build
-  - test/testcases_fast.sh --all
+  - .travis/travis_script.sh
 after_success:
   - coveralls
 after_failure:
-  - cat ~/.local/var/pmbootstrap/log.txt
-  - cat ~/.local/var/pmbootstrap/log_testsuite.txt
+  - .travis/travis_after_failure.sh
 notifications:
   - email: false

--- a/.travis/common.sh
+++ b/.travis/common.sh
@@ -1,0 +1,45 @@
+# Source: .travis/common.sh from Alpine's aports repo
+
+die() {
+	print -s1 -c1 "$@\n" 1>&2
+	exit 1
+}
+
+# Marks start of named folding section for Travis and prints title.
+fold_start() {
+	local name="$1"
+	local title="$2"
+
+	printf "\ntravis_fold:start:$name "
+	print -s1 -c6 "> $title\n"
+}
+
+# Marks end of the named folding section.
+fold_end() {
+	local name="$1"
+
+	printf "travis_fold:end:$name\n"
+}
+
+# Prints formatted and colored text.
+print() {
+	local style=0
+	local fcolor=9
+
+	local opt; while getopts 's:c:' opt; do
+		case "$opt" in
+			s) style="$OPTARG";;
+			c) fcolor="$OPTARG";;
+		esac
+	done
+
+	shift $(( OPTIND - 1 ))
+	local text="$@"
+
+	printf "\033[${style};3${fcolor}m$text\033[0m"
+}
+
+title() {
+	printf '\n'
+	print -s1 -c6 "==> $@\n"
+}

--- a/.travis/travis_after_failure.sh
+++ b/.travis/travis_after_failure.sh
@@ -8,11 +8,11 @@ cd "$DIR/.."
 . .travis/common.sh
 
 # pmbootstrap log
-fold_start "pmbootstrap log" "Printing pmbootstrap log file"
+fold_start "log.1" "pmbootstrap log"
 cat ~/.local/var/pmbootstrap/log.txt
-fold_end "pmbootstrap log"
+fold_end "log.1"
 
 # Testsuite log
-fold_start "testsuite log" "Printing testsuite log file"
+fold_start "log.2" "Testsuite log"
 cat ~/.local/var/pmbootstrap/log_testsuite.txt
-fold_end "testsuite log"
+fold_end "log.2"

--- a/.travis/travis_after_failure.sh
+++ b/.travis/travis_after_failure.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+
+# Go to pmbootstrap folder
+DIR="$(cd "$(dirname "$0")" && pwd -P)"
+cd "$DIR/.."
+
+# Functions for pretty Travis output
+. .travis/common.sh
+
+# pmbootstrap log
+fold_start "pmbootstrap log" "Printing pmbootstrap log file"
+cat ~/.local/var/pmbootstrap/log.txt
+fold_end "pmbootstrap log"
+
+# Testsuite log
+fold_start "testsuite log" "Printing testsuite log file"
+cat ~/.local/var/pmbootstrap/log_testsuite.txt
+fold_end "testsuite log"

--- a/.travis/travis_script.sh
+++ b/.travis/travis_script.sh
@@ -8,28 +8,26 @@ cd "$DIR/.."
 . .travis/common.sh
 
 # Static code analysis
-fold_start "static code analysis" "Static code analysis"
+fold_start "static_analysis" "Static code analysis"
 test/static_code_analysis.sh
-fold_end "static code analysis"
+fold_end "static_analysis"
 
 # pmbootstrap init
-fold_start "pmbootstrap init" "Initializing pmbootstrap with defaults"
+fold_start "init" "pmbootstrap init"
 yes "" | ./pmbootstrap.py init
-fold_end "pmbootstrap init"
+fold_end "init"
 
 # pmbootstrap kconfig_check
-fold_start "pmbootstrap kconfig_check" "Checking all kernel configs"
+fold_start "kconfig_check" "pmbootstrap kconfig_check"
 ./pmbootstrap.py kconfig_check
-fold_end "pmbootstrap kconfig_check"
+fold_end "kconfig_check"
 
 # pmbootstrap build --strict
-fold_start "pmbootstrap build --strict" \
-	"Building all changed aports in strict mode"
+fold_start "build" "pmbootstrap build --strict"
 test/check_checksums.py --build
-fold_end "pmbootstrap build --strict"
+fold_end "build"
 
 # Testsuite
-fold_start "testsuite" "Running the testsuite"
+fold_start "testsuite" "Testsuite and code coverage"
 test/testcases_fast.sh --all
 fold_end "testsuite"
-

--- a/.travis/travis_script.sh
+++ b/.travis/travis_script.sh
@@ -1,0 +1,35 @@
+#!/bin/sh -e
+
+# Go to pmbootstrap folder
+DIR="$(cd "$(dirname "$0")" && pwd -P)"
+cd "$DIR/.."
+
+# Functions for pretty Travis output
+. .travis/common.sh
+
+# Static code analysis
+fold_start "static code analysis" "Static code analysis"
+test/static_code_analysis.sh
+fold_end "static code analysis"
+
+# pmbootstrap init
+fold_start "pmbootstrap init" "Initializing pmbootstrap with defaults"
+yes "" | ./pmbootstrap.py init
+fold_end "pmbootstrap init"
+
+# pmbootstrap kconfig_check
+fold_start "pmbootstrap kconfig_check" "Checking all kernel configs"
+./pmbootstrap.py kconfig_check
+fold_end "pmbootstrap kconfig_check"
+
+# pmbootstrap build --strict
+fold_start "pmbootstrap build --strict" \
+	"Building all changed aports in strict mode"
+test/check_checksums.py --build
+fold_end "pmbootstrap build --strict"
+
+# Testsuite
+fold_start "testsuite" "Running the testsuite"
+test/testcases_fast.sh --all
+fold_end "testsuite"
+

--- a/test/testcases_fast.sh
+++ b/test/testcases_fast.sh
@@ -35,4 +35,4 @@ done
 
 # Run enabled testcases with coverage enabled
 # shellcheck disable=SC2086
-pytest --cov=pmb $enabled
+pytest --cov=pmb $enabled --tb=native


### PR DESCRIPTION
### [Example output](https://travis-ci.org/postmarketOS/pmbootstrap/builds/353031522)

### Changes
* Moved the `script` and `after_failure` sections of `.travis.yml`
  to extra files in a new `.travis/` folder
* Copy paste `.travis/common.sh` from Alpine's aports. They have neat
  formatting functions in there for folding
* Add a folding block around each script that gets called
* Use native tracebacks in pytest. These are the same as we see when
  pmbootstrap crashes usually, instead of printing out the entire
  function that causes an error. I think this makes the error output
  easier to read.

EDIT: Closes #1255.