### PR TITLE
Package resolving: Don't fail on fuzzy versions

### DIFF
--- a/pmb/parse/apkindex.py
+++ b/pmb/parse/apkindex.py
@@ -98,7 +98,7 @@ def parse_next_block(args, path, lines, start):
                 for value in values:
                     if value.startswith("!"):
                         continue
-                    for operator in [">", "=", "<"]:
+                    for operator in [">", "=", "<", "~"]:
                         if operator in value:
                             value = value.split(operator)[0]
                             break


### PR DESCRIPTION
When parsing the depends of entries in the APKINDEX file, we ignore
all operators (`<`, `=`, `>`). (This is enough for our use case, was we only
do the dependency resolving to check which packages need to be built
and `apk` does the dependency resolving again before installing
anything).

We did not ignore the `~` character for fuzzy version compares, this is
fixed with this commit.

### How to test
Run this command before and after applying the PR. This is what happens without the PR:
```
$ pmbootstrap chroot --add=ocaml-camlp4
...
ERROR: Could not find package 'ocaml-runtime~4.06' in any aports folder or APKINDEX.
...
```

Fixes #1344.