### PR TITLE
Fix dependency resolver being stuck after reboot

### DIFF
--- a/pmb/parse/apkindex.py
+++ b/pmb/parse/apkindex.py
@@ -196,8 +196,11 @@ def parse(args, path, multiple_providers=True):
     cache_key = "multiple" if multiple_providers else "single"
     if path in args.cache["apkindex"]:
         cache = args.cache["apkindex"][path]
-        if cache["lastmod"] == lastmod and cache_key in cache:
-            return cache[cache_key]
+        if cache["lastmod"] == lastmod:
+            if cache_key in cache:
+                return cache[cache_key]
+        else:
+            clear_cache(args, path)
 
     # Read all lines
     if tarfile.is_tarfile(path):


### PR DESCRIPTION
## Summary
When the native arch (e.g. `x86_64`) `APKINDEX` files are outdated, and
`pmbootstrap` gets instructed to build a linux package for a foreign
arch, then the `APKINDEX` cache did not get used anymore for the
current session. This means that every lookup of a package in an
`APKINDEX` caused the whole `APKINDEX` file to get parsed again instead
of using the cached version. This slowed it down so much that it felt
like `pmbootstrap` was looping forever.

## Details
* Whenever pmbootstrap parses an `APKINDEX`, it fills up the
  `args.cache["apkindex"]` dict with the parsed information and the
  last modified date of the file.
* `pmbootstrap` checks the last modified date of the `APKINDEX` files
  and updates them if they are older than 4 hours.
* When the bug appeared, then the cache was already filled up, then an
  update happened and then `pmbootstrap` tried to read from the cache.
* So when reading from the `APKINDEX`, the cache gets ignored because
  the last modified date is different.
* Up to this commit, the cache does not get deleted and filled up
  again!

## How to test
Try these commands once without this commit, and then with this commit
applied:
```
$ sudo touch -m -t 201801010000 \
    ~/.local/var/pmbootstrap/cache_apk_x86_64/APKINDEX.*
$ pmbootstrap -v build linux-postmarketos-mainline --arch=armhf
```

Without the patch, you can see in `pmbootstrap log` that it is
resolving the dependencies properly, but very slowly. With the patch
the resolving happens almost instantly.

Fixes #1351.