### PR TITLE
Disable metadata_csum when generating ext4 rootfs

### DIFF
--- a/pmb/install/format.py
+++ b/pmb/install/format.py
@@ -58,7 +58,9 @@ def format_and_mount_pm_crypt(args):
     # Format
     if not args.rsync:
         logging.info("(native) format " + device)
-        pmb.chroot.root(args, ["mkfs.ext4", "-F", "-q", "-L", "pmOS_root", device])
+        # Some downstream kernels don't have metadata_csum yet (#1364)
+        pmb.chroot.root(args, ["mkfs.ext4", "-O", "^metadata_csum", "-F",
+                               "-q", "-L", "pmOS_root", device])
 
     # Mount
     mountpoint = "/mnt/install"


### PR DESCRIPTION
Some downstream kernels don't support this, and this recently became the default in e2fsprogs.

@fooforever and @drebrez: unfortunately I could not reproduce the issue with my `samsung-i9100`, it boots through straight to weston, even with a fresh image I've just created. So I am not sure if it really fixes #1364. Could one of you test this patch?