### PR TITLE
"pkgrel_bump --auto": Handle subpackages properly

### DIFF
--- a/test/testdata/pkgrel_bump/aports/testsubpkg/APKBUILD
+++ b/test/testdata/pkgrel_bump/aports/testsubpkg/APKBUILD
@@ -1,0 +1,33 @@
+pkgname=testsubpkg
+pkgver=1.0
+pkgrel=0
+pkgdesc="subpackage using the testlib (for testing soname bumps)"
+url="https://postmarketos.org"
+arch="all"
+license="MIT"
+depends=""
+makedepends="testlib"
+subpackages="$pkgname-app"
+source="testapp.c"
+options=""
+
+build() {
+	cd "$srcdir"
+	$CC testapp.c -o testapp -L/usr/lib/ -ltestlib
+}
+
+check() {
+	cd "$srcdir"
+	printf 'hello, world from testlib!\n' > expected
+	./testapp > real
+	diff -q expected real
+}
+
+package() {
+    mkdir -p "$pkgdir"
+}
+
+app() {
+	install -Dm755 "$srcdir/testapp" "$subpkgdir/usr/bin/testapp"
+}
+sha512sums="73b167575dc0082a1277b0430f095509885c7aaf55e59bad148825a9879f91fe41c6479bb7f34c0cdd15284b0aadd904a5ba2c1ea85fb8bfb061e1cbf4322d76  testapp.c"

--- a/test/testdata/pkgrel_bump/aports/testsubpkg/testapp.c
+++ b/test/testdata/pkgrel_bump/aports/testsubpkg/testapp.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include <testlib.h>
+
+int main(int argc, char **argv) {
+    testlib_hello();
+    return 0;
+}


### PR DESCRIPTION
`pmbootstrap pkgrel_bump --auto` automatically increases the pkgrel for
packages linking against libraries, which don't exist anymore (because
the soname has been changed). The feature is explained in detail in

The previous implementation did not detect soname breakage, when a
subpackage linked against a certain library, but the main package
did not (e.g. `qt5-qtbase-mysql` and `qt5-qtbase`). This was, because
we iterated over the aports/* to find the packages to be checked.

To fix this, we are iterating over the packages found in the APKINDEX
files instead (of both the locally compiled packages and the downloaded
index from the pmOS mirror).

Details:
* `pmb/helpers/pkgrel_bump.py`:
  * Rewrite `auto_apkindex_package()` to act upon a given parsed
    `aport` and `apk` (from the index) instead of finding the `apk`
    dict by itself (we need it earlier anyway).
  * Rewrite `auto()` to iterate over APKINDEX files instead of aports
    * Skip packages already found, so the `pkgrel` does not get
      increased multiple times when the same package was found in
      multipe index files.
* Put the package name at the beginning of the log messages to make
  them more readable
* testdata: Create a new `testsubpkg` aport, where only the subpackage
  links against `testlib`
* Adjust testing code to test everything with `testsubpkg` as well.

NOTE: This makes the command a bit slower, but we could improve
performance again by smart caching of `pmb.parse.apkindex.depends()`.
This could come in a future PR, the important part here is that the
command is bug-free again with this fix.

Fixes #1379.