### PR TITLE
osk-sdl: Update to 0.52

### DIFF
--- a/aports/main/osk-sdl/APKBUILD
+++ b/aports/main/osk-sdl/APKBUILD
@@ -1,5 +1,5 @@
 pkgname=osk-sdl
-pkgver=0.51
+pkgver=0.52
 pkgrel=0
 pkgdesc="Onscreen keyboard for unlocking LUKS devices"
 url="https://github.com/postmarketOS/osk-sdl"
@@ -18,9 +18,9 @@ build() {
 }
 
 package() {
-    install -D -m755 "${srcdir}/${pkgname}-${pkgver}"/osk-sdl \
+    install -D -m755 "${srcdir}/${pkgname}-${pkgver}"/bin/osk-sdl \
         "$pkgdir"/usr/bin/osk-sdl
     install -D -m755 "${srcdir}/${pkgname}-${pkgver}"/osk.conf \
         "$pkgdir"/etc/osk.conf
 }
-sha512sums="0adf343d9641654dec5be8c3ba06d1b7bbd7738f0c1a5afa6672e3824b08c66985103fe8ba807da63fcf83d2a640b73b7bd449ec1805fc152522190debb65c87  osk-sdl-0.51-0.tar.gz"
+sha512sums="ce2f17113d41b9c43c37148c18a547c4e09e26fdf86eb19d25b2761712065b2f2f45e34dcb5ec9be29a8c356c4430a881eedf9130e8a05d0645c97b26c756eb0  osk-sdl-0.52-0.tar.gz"


### PR DESCRIPTION
The code got refactored. Updating the version used in pmbootstrap, so
it does not diverge too much.

Changes:
https://github.com/postmarketOS/osk-sdl/releases/tag/0.52

It worked on my `samsung-i9100`. But it would be good if someone else reviewed the small change and tested it on their device as well.