### PR TITLE
Display wiki link on dependency error

### DIFF
--- a/pmb/parse/depends.py
+++ b/pmb/parse/depends.py
@@ -151,12 +151,9 @@ def recurse(args, pkgnames, suffix="native"):
 
         # Nothing found
         if not package:
-            logging.info("NOTE: Run 'pmbootstrap pkgrel_bump --auto' to mark"
-                         " packages with outdated dependencies for rebuild."
-                         " This will most likely fix this issue (soname"
-                         " bump?).")
-            raise RuntimeError("Could not find package '" + pkgname_depend +
-                               "' in any aports folder or APKINDEX.")
+            raise RuntimeError("Could not find dependency '" + pkgname_depend +
+                               "' in any aports folder or APKINDEX. See:"
+                               " <https://postmarketos.org/depends>")
 
         # Append to todo/ret (unless it is a duplicate)
         pkgname = package["pkgname"]

--- a/test/test_parse_depends.py
+++ b/test/test_parse_depends.py
@@ -133,7 +133,7 @@ def test_recurse_invalid(args, monkeypatch):
     # Invalid package
     with pytest.raises(RuntimeError) as e:
         func(args, ["invalid-pkgname"])
-    assert str(e.value).startswith("Could not find package")
+    assert str(e.value).startswith("Could not find dependency")
 
 
 def return_none(*args, **kwargs):


### PR DESCRIPTION
Turns out the reasons why a dependency could not be found are not that simple, and the message we had was not that helpful (e.g. in #1408, but there are more examples). Here's a new wiki page, that explains the issue in depth and how to fix it for each scenario: https://wiki.postmarketos.org/wiki/Troubleshooting:dependencies

Current:
> `NOTE: Run 'pmbootstrap pkgrel_bump --auto' to mark packages with outdated dependencies for rebuild. This will most likely fix this issue (soname bump?)`
> `ERROR: Could not find package 'so:libcrypto.so.42' in any aports folder or APKINDEX.`

New:
> `ERROR: Could not find dependency 'so:libcrypto.so.42' in any aports folder or APKINDEX. See: <https://postmarketos.org/depends>`