### PR TITLE
firmwareload: log to system log

### DIFF
--- a/aports/main/postmarketos-base/APKBUILD
+++ b/aports/main/postmarketos-base/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=postmarketos-base
 pkgver=3
-pkgrel=16
+pkgrel=17
 pkgdesc="Meta package for minimal postmarketOS base"
 url="https://github.com/postmarketOS"
 arch="noarch"
@@ -65,7 +65,7 @@ x11() {
 	mkdir "$subpkgdir"
 }
 
-sha512sums="38dc75c0ed32b76dccd3d8e7e8173e8b7d91847cf2b07123f376b95af46b4f89798b24f45302a0726fdc1cf253aecaac140f431735ac5c6511553f790badd0af  firmwareload.sh
+sha512sums="9412eb9be2a727f961e15a043731d307887e9ee8e52675c91604c786e6e96b77838a706b26a758decc2053f5daa9d94a9a545b3ce45c47cb8af02e5e792f8966  firmwareload.sh
 0b098828080055d3646ea54891cb0e1b578cbc30f5e16f7284f2814c08192f18079a38fb686d192715ae6a3d2cd6625d9e3cf99f234a6f0d94088bb0cb2ce43d  50-firmware.rules
 f6750935cd304eb8c248f7bc65bed0c8bcd27c00bb8d0565f85ab8cfd5769cf5e8b1f27a7c851edc8236d80b014fb513e42951953fc403d8f47769776122e275  networkmanager.conf
 3ceeee37f558e7c95ad973692b6a437f997e6b46c3d1c2257ddfb1529a5633477373aa123c7f08164e818daae50acb203d151379f27ca11bd458809e6a0d4de7  swapfile

--- a/aports/main/postmarketos-base/firmwareload.sh
+++ b/aports/main/postmarketos-base/firmwareload.sh
@@ -2,23 +2,23 @@
 
 FIRMWARE_DIRS="/lib/firmware /lib/firmware/postmarketos"
 
-exec >>/var/log/firmwareload.log 2>&1
+(
+	if [ ! -e "/sys/$DEVPATH/loading" ]; then
+		echo "firmware loader misses sysfs directory"
+		exit 1
+	fi
 
-if [ ! -e "/sys/$DEVPATH/loading" ]; then
-    echo "firmware loader misses sysfs directory"
-    exit 1
-fi
+	for DIR in $FIRMWARE_DIRS; do
+		[ -e "$DIR/$FIRMWARE" ] || continue
+		echo "loading $DIR/$FIRMWARE"
+		echo 1 > "/sys/$DEVPATH/loading"
+		cat "$DIR/$FIRMWARE" > "/sys/$DEVPATH/data"
+		echo 0 > "/sys/$DEVPATH/loading"
+		exit 0
+	done
 
-for DIR in $FIRMWARE_DIRS; do
-    [ -e "$DIR/$FIRMWARE" ] || continue
-    echo "loading $DIR/$FIRMWARE"
-    echo 1 > "/sys/$DEVPATH/loading"
-    cat "$DIR/$FIRMWARE" > "/sys/$DEVPATH/data"
-    echo 0 > "/sys/$DEVPATH/loading"
-    exit 0
-done
-
-# shellcheck disable=SC2039
-echo -1 > "/sys/$DEVPATH/loading"
-echo "cannot find firmware file '$FIRMWARE'"
-exit 1
+	# shellcheck disable=SC2039
+	echo -1 > "/sys/$DEVPATH/loading"
+	echo "cannot find firmware file '$FIRMWARE'"
+	exit 1
+) 2>&1 | logger -t "firmwareload"


### PR DESCRIPTION
Is there a reason this wasn't done originally? Maybe we can't count on syslogd being up. Now I'm wondering if this patch is a bad idea for that reason.