### PR TITLE
Set all of user's groups in "pmbootstrap install"

### DIFF
--- a/aports/main/postmarketos-base/APKBUILD
+++ b/aports/main/postmarketos-base/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=postmarketos-base
 pkgver=3
-pkgrel=16
+pkgrel=17
 pkgdesc="Meta package for minimal postmarketOS base"
 url="https://github.com/postmarketOS"
 arch="noarch"

--- a/aports/main/postmarketos-base/postmarketos-base.post-install
+++ b/aports/main/postmarketos-base/postmarketos-base.post-install
@@ -76,10 +76,6 @@ touch /etc/wpa_supplicant/wpa_supplicant.conf
 # Enable the 'wheel' group
 sed -i 's/# %wheel ALL=(ALL) ALL/%wheel ALL=(ALL) ALL/' /etc/sudoers
 
-# Add user to video group for proper framebuffer permissions
-username="$(getent passwd 1000 | cut -d ":" -f 1)"
-usermod -a -G video,audio "$username"
-
 # Set chrony to quickly correct system time on first boot, if necessary
 if ! grep -q "makestep" /etc/chrony/chrony.conf; then
 	echo "makestep 1 -1" >> /etc/chrony/chrony.conf

--- a/pmb/config/__init__.py
+++ b/pmb/config/__init__.py
@@ -287,6 +287,9 @@ install_device_packages = [
     "ttf-droid"
 ]
 
+# Groups for the default user
+install_user_groups = ["wheel", "video", "audio"]
+
 
 #
 # FLASH

--- a/pmb/install/_install.py
+++ b/pmb/install/_install.py
@@ -184,7 +184,8 @@ def set_user(args):
     if not pmb.chroot.user_exists(args, args.user, suffix):
         pmb.chroot.root(args, ["adduser", "-D", "-u", "1000", args.user],
                         suffix)
-        pmb.chroot.root(args, ["addgroup", args.user, "wheel"], suffix)
+        for group in pmb.config.install_user_groups:
+            pmb.chroot.root(args, ["addgroup", args.user, group], suffix)
 
 
 def setup_login(args):


### PR DESCRIPTION
The `postmarketos-base` package used to make the user part of the "video"
and "audio" groups. However, this did not work reliably, and we were
adding the "wheel" group in `pmbootstrap install` anyway.

Now all groups get added in `pmbootstrap install`, and the names of the
groups have been moved to `pmb.config.install_user_groups`.

Fixes #1431. Worked as I tested it, but as usually please test and review :+1: 