### PR TITLE
GitHub templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,4 +16,7 @@
         * Check "logread" on the device and attach the output if it could be
           useful.
         * Run "logread" on the device, does it output anything useful?
+
+    Please insert your text below and feel free to delete this big comment
+    block after reading.
 -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+    When making a bug report, please consider the following notes.
+
+    * Is the error already described here?
+        https://postmarketos.org/troubleshooting
+    * pmbootstrap:
+        * Attach the output of "pmbootstrap log" in this issue
+        * In case "pmbootstrap log" is not helpful, try running the command
+          which causes the error with "-v" (e.g. "pmbootstrap -v install")
+    * osk-sdl:
+        * Please report here: https://github.com/postmarketOS/osk-sdl/issues
+    * kernel issue:
+        * Check "dmesg" on the device and attach the output if it could be
+          useful.
+    * X11/wayland/other userspace program issue:
+        * Check "logread" on the device and attach the output if it could be
+          useful.
+        * Run "logread" on the device, does it output anything useful?
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+    We appreciate that you are about to create a pull request!
+
+    In order to get it tested (code change), reviewed and merged quickly,
+    please take a look at the following notes.
+
+    1. We only merge PRs that pass all tests:
+        * As soon as you create the PR, automatic tests will run with Travis CI
+        * Come back later to see if everything passed
+        * Click on the failed test icon to see why it failed and try to fix it
+        * In case Travis failed for a reason not related to your changes (e.g.
+          network issues or missing documentation), push an empty commit:
+            git commit --allow-empty -m 'run tests again'
+        * You can run the tests locally as well:
+            test/static_code_analysis.sh
+            test/testcases_fast.sh
+    2. All commits in the PR will get squashed into one (so you don't need to
+       do that).
+    3. New device:
+        * Is it documented in the wiki?
+    4. Code change:
+        * Depending on the complexity of the change, consider structuring your
+          PR message with headlines (### headline) in sections, e.g.:
+            * Overview (context and short description of the change)
+            * Usage example (cli output)
+            * Changes (detailed list of every change made)
+            * How to test
+        * Add 'Close #nnnn' or 'Fixes #nnnn' at the bottom to automatically
+          close issue nnnn as soon as your PR gets merged.
+-->
+
+
+
+
+---
+[x] Merge on GitHub (see <https://postmarketos.org/merge>)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,10 +27,9 @@
             * How to test
         * Add 'Close #nnnn' or 'Fixes #nnnn' at the bottom to automatically
           close issue nnnn as soon as your PR gets merged.
+
+    Please insert your text before the --- line, feel free to delete this big
+    comment block after reading.
 -->
-
-
-
-
 ---
 [x] Merge on GitHub (see <https://postmarketos.org/merge>)


### PR DESCRIPTION
Adding two templates for new issues and new pull requests. The new PR template asks the user whether merging via GitHub button is okay and links to this new wiki page: https://wiki.postmarketos.org/wiki/Merge_Workflow

Close #1319 , close #1374.