### PR TITLE
Fix for n900 audio not working

### DIFF
--- a/aports/main/linux-postmarketos-stable/APKBUILD
+++ b/aports/main/linux-postmarketos-stable/APKBUILD
@@ -4,7 +4,7 @@ _config="config-${_flavor}.${CARCH}"
 
 pkgname=linux-${_flavor}
 
-pkgver=4.15.12
+pkgver=4.16.2
 case $pkgver in
 	*.*.*)	_kernver=${pkgver%.*};;
 	*.*) _kernver=$pkgver;;
@@ -15,7 +15,7 @@ arch="x86_64 armhf aarch64"
 pkgdesc="Linux for pmOS supported chipsets (stable)"
 url="https://kernel.org/"
 depends=""
-makedepends="perl sed installkernel bash gmp-dev bc linux-headers elfutils-dev libressl-dev file"
+makedepends="perl sed installkernel bash gmp-dev bc linux-headers elfutils-dev libressl-dev file bison flex"
 options="!strip !check !tracedeps"
 install=
 source="
@@ -192,8 +192,8 @@ dev() {
 	fi
 }
 
-sha512sums="c00d92659df815a53dcac7dde145b742b1f20867d380c07cb09ddb3295d6ff10f8931b21ef0b09d7156923a3957b39d74d87c883300173b2e20690d2b4ec35ea  linux-4.15.tar.xz
+sha512sums="ab47849314b177d0eec9dbf261f33972b0d89fb92fb0650130ffa7abc2f36c0fab2d06317dc1683c51a472a9a631573a9b1e7258d6281a2ee189897827f14662  linux-4.16.tar.xz
 7e4485a97ca37db7d071ebafa29450c2f307b51d48dac5c9f947d2f33c3194b1263f265031bbb502ac1d94039f0779d9528ef24491fa83260b9b78fcfe3c6c46  config-postmarketos-stable.armhf
 5e3c7d569b6a246ed5873afb088dbcd533cb1074f13a030292af41214a704ea08d9c5505b113429ded57849271c121bfef1b7771cb3051d2ac46808da13afa45  config-postmarketos-stable.aarch64
 9b7ae9e35731675db311aea9fe45b0e1ecc97cc40edc1ed7b179945e49d5656f26706c7fbf76a5308b0f480831adcfcff2777cb024c214c2e7a53b5ef0a15cd0  config-postmarketos-stable.x86_64
-5f6f43a8ac40346a88c27886e1aab1266efc7de0f1994c7bee42e8501697123c3f7217be2368c2addd2d63ab357bc426d9eab568252659341c0c9327b9179ff1  patch-4.15.12.xz"
+3b9e2b8019f002443c7cd6510a878ab537351842e522848bdccd185dad6ea2b78a19b5c9179cd10aacccf20941632fd42340a5a3cef48ac875e57bd6cb3d57eb  patch-4.16.2.xz"


### PR DESCRIPTION
Updating kernel to 4.16.2. Added `bison` and `flex`, as build otherwise fails. This effectively fixes the audio problems we were having in the previous kernel version.