### PR TITLE
Add install flag to generate separate boot and system images

### DIFF
--- a/pmb/export/frontend.py
+++ b/pmb/export/frontend.py
@@ -1,3 +1,4 @@
+import glob
 import logging
 import os
 
@@ -13,10 +14,11 @@ def frontend(args):
     if not os.path.exists(target):
         pmb.helpers.run.user(args, ["mkdir", "-p", target])
 
-    # System image note
-    img_path = "/home/pmos/rootfs/" + args.device + ".img"
-    if not os.path.exists(args.work + "/chroot_native" + img_path):
-        logging.info("NOTE: To export the system image, run 'pmbootstrap"
+    # Rootfs image note
+    chroot = args.work + "/chroot_native"
+    pattern = chroot + "/home/pmos/rootfs/" + args.device + "*.img"
+    if not glob.glob(pattern):
+        logging.info("NOTE: To export the rootfs image, run 'pmbootstrap"
                      " install' first (without the 'sdcard' parameter).")
 
     # Rebuild the initramfs, just to make sure (see #69)

--- a/pmb/export/symlinks.py
+++ b/pmb/export/symlinks.py
@@ -42,6 +42,8 @@ def symlinks(args, flavor, folder):
         "uImage-" + flavor: "Kernel, legacy u-boot image format",
         "vmlinuz-" + flavor: "Linux kernel",
         args.device + ".img": "Rootfs with partitions for /boot and /",
+        args.device + "-boot.img": "Boot partition image",
+        args.device + "-system.img": "System partition image",
         "pmos-" + args.device + ".zip": "Android recovery flashable zip",
     }
 
@@ -51,6 +53,8 @@ def symlinks(args, flavor, folder):
     path_buildroot = args.work + "/chroot_buildroot_" + args.deviceinfo["arch"]
     patterns = [path_boot + "/*-" + flavor,
                 path_native + "/home/pmos/rootfs/" + args.device + ".img",
+                path_native + "/home/pmos/rootfs/" + args.device + "-boot.img",
+                path_native + "/home/pmos/rootfs/" + args.device + "-system.img",
                 path_buildroot +
                 "/var/lib/postmarketos-android-recovery-installer/pmos-" +
                 args.device + ".zip"]

--- a/pmb/export/symlinks.py
+++ b/pmb/export/symlinks.py
@@ -43,7 +43,7 @@ def symlinks(args, flavor, folder):
         "vmlinuz-" + flavor: "Linux kernel",
         args.device + ".img": "Rootfs with partitions for /boot and /",
         args.device + "-boot.img": "Boot partition image",
-        args.device + "-system.img": "System partition image",
+        args.device + "-root.img": "Root partition image",
         "pmos-" + args.device + ".zip": "Android recovery flashable zip",
     }
 
@@ -54,7 +54,7 @@ def symlinks(args, flavor, folder):
     patterns = [path_boot + "/*-" + flavor,
                 path_native + "/home/pmos/rootfs/" + args.device + ".img",
                 path_native + "/home/pmos/rootfs/" + args.device + "-boot.img",
-                path_native + "/home/pmos/rootfs/" + args.device + "-system.img",
+                path_native + "/home/pmos/rootfs/" + args.device + "-root.img",
                 path_buildroot +
                 "/var/lib/postmarketos-android-recovery-installer/pmos-" +
                 args.device + ".zip"]

--- a/pmb/install/_install.py
+++ b/pmb/install/_install.py
@@ -348,9 +348,14 @@ def install_system_image(args):
                      " Use 'pmbootstrap flasher boot' to do that.)")
 
     # Export information
-    logging.info("* If the above steps do not work, you can also create"
-                 " symlinks to the generated files with 'pmbootstrap export'"
-                 " and flash outside of pmbootstrap.")
+    if args.split:
+        logging.info("* Boot and root image files have been generated, run"
+                     " 'pmbootstrap export' to create symlinks and flash"
+                     " outside of pmbootstrap")
+    else:
+        logging.info("* If the above steps do not work, you can also create"
+                     " symlinks to the generated files with 'pmbootstrap export'"
+                     " and flash outside of pmbootstrap.")
 
 
 def install_recovery_zip(args):

--- a/pmb/install/_install.py
+++ b/pmb/install/_install.py
@@ -351,7 +351,7 @@ def install_system_image(args):
     if args.split:
         logging.info("* Boot and root image files have been generated, run"
                      " 'pmbootstrap export' to create symlinks and flash"
-                     " outside of pmbootstrap")
+                     " outside of pmbootstrap.")
     else:
         logging.info("* If the above steps do not work, you can also create"
                      " symlinks to the generated files with 'pmbootstrap export'"

--- a/pmb/install/_install.py
+++ b/pmb/install/_install.py
@@ -46,9 +46,9 @@ def mount_device_rootfs(args, suffix="native"):
 
 def get_subpartitions_size(args):
     """
-    Calculate the size of the boot and system subpartition.
+    Calculate the size of the boot and root subpartition.
 
-    :returns: (boot, system) the size of the boot and system
+    :returns: (boot, root) the size of the boot and root
               partition as integer in bytes
     """
     # Calculate required sizes first
@@ -284,9 +284,9 @@ def install_system_image(args):
     # Partition and fill image/sdcard
     logging.info("*** (3/5) PREPARE INSTALL BLOCKDEVICE ***")
     pmb.chroot.shutdown(args, True)
-    (size_boot, size_system) = get_subpartitions_size(args)
+    (size_boot, size_root) = get_subpartitions_size(args)
     if not args.rsync:
-        pmb.install.blockdevice.create(args, size_boot, size_system)
+        pmb.install.blockdevice.create(args, size_boot, size_root)
         if not args.split:
             pmb.install.partition(args, size_boot)
     if not args.split:

--- a/pmb/install/_install.py
+++ b/pmb/install/_install.py
@@ -46,9 +46,9 @@ def mount_device_rootfs(args, suffix="native"):
 
 def get_subpartitions_size(args):
     """
-    Calculate the size of the whole image and boot subpartition.
+    Calculate the size of the boot and system subpartition.
 
-    :returns: (full, boot) the size of the full image and boot
+    :returns: (boot, system) the size of the boot and system
               partition as integer in bytes
     """
     # Calculate required sizes first
@@ -66,7 +66,7 @@ def get_subpartitions_size(args):
     full *= 1.20
     full += 50 * 1024 * 1024
     boot += 15 * 1024 * 1024
-    return (full, boot)
+    return (boot, full - boot)
 
 
 def get_nonfree_packages(args, device):
@@ -284,11 +284,13 @@ def install_system_image(args):
     # Partition and fill image/sdcard
     logging.info("*** (3/5) PREPARE INSTALL BLOCKDEVICE ***")
     pmb.chroot.shutdown(args, True)
-    (size_image, size_boot) = get_subpartitions_size(args)
+    (size_boot, size_system) = get_subpartitions_size(args)
     if not args.rsync:
-        pmb.install.blockdevice.create(args, size_image)
-        pmb.install.partition(args, size_boot)
-    pmb.install.partitions_mount(args)
+        pmb.install.blockdevice.create(args, size_boot, size_system)
+        if not args.split:
+            pmb.install.partition(args, size_boot)
+    if not args.split:
+        pmb.install.partitions_mount(args)
 
     if args.full_disk_encryption:
         logging.info("WARNING: Full disk encryption is enabled!")
@@ -309,7 +311,7 @@ def install_system_image(args):
     pmb.chroot.shutdown(args, True)
 
     # Convert system image to sparse using img2simg
-    if args.deviceinfo["flash_sparse"] == "true":
+    if args.deviceinfo["flash_sparse"] == "true" and not args.split:
         logging.info("(native) make sparse system image")
         pmb.chroot.apk.install(args, ["libsparse"])
         sys_image = args.device + ".img"
@@ -325,7 +327,7 @@ def install_system_image(args):
                  " target device:")
 
     # System flash information
-    if not args.sdcard:
+    if not args.sdcard and not args.split:
         logging.info("* pmbootstrap flasher flash_rootfs")
         logging.info("  Flashes the generated rootfs image to your device:")
         logging.info("  " + args.work + "/chroot_native/home/pmos/rootfs/" +

--- a/pmb/install/blockdevice.py
+++ b/pmb/install/blockdevice.py
@@ -124,8 +124,8 @@ def create_and_mount_image(args, size_boot, size_root):
     if not args.split:
         mount_image_paths.append([img_path_full, "/dev/install"])
     else:
-        mount_image_paths.append([img_path_boot, "/dev/install-boot"])
-        mount_image_paths.append([img_path_root, "/dev/install-root"])
+        mount_image_paths.append([img_path_boot, "/dev/installp1"])
+        mount_image_paths.append([img_path_root, "/dev/installp2"])
 
     for img_path, mount_point in mount_image_paths:
         logging.info("(native) mount " + mount_point +

--- a/pmb/install/blockdevice.py
+++ b/pmb/install/blockdevice.py
@@ -70,56 +70,82 @@ def mount_sdcard(args):
             raise RuntimeError("Aborted.")
 
 
-def create_and_mount_image(args, size):
+def create_and_mount_image(args, size_boot, size_system):
     """
     Create a new image file, and mount it as /dev/install.
 
-    :param size: of the whole image in bytes
+    :param size_boot: size of the boot partition in bytes
+    :param size_system: size of the system partition in bytes
     """
     # Short variables for paths
     chroot = args.work + "/chroot_native"
-    img_path = "/home/pmos/rootfs/" + args.device + ".img"
-    img_path_outside = chroot + img_path
+    img_path_full = "/home/pmos/rootfs/" + args.device + ".img"
+    img_path_outside_full = chroot + img_path_full
+    img_path_boot = "/home/pmos/rootfs/" + args.device + "-boot.img"
+    img_path_outside_boot = chroot + img_path_boot
+    img_path_system = "/home/pmos/rootfs/" + args.device + "-system.img"
+    img_path_outside_system = chroot + img_path_system
 
-    # Umount and delete existing image
-    if os.path.exists(img_path_outside):
-        pmb.helpers.mount.umount_all(args, chroot + "/mnt")
-        pmb.install.losetup.umount(args, img_path)
-        pmb.chroot.root(args, ["rm", img_path])
+    # Umount and delete existing images
+    for img_path, img_path_outside in [[img_path_full, img_path_outside_full],
+                                       [img_path_boot, img_path_outside_boot],
+                                       [img_path_system, img_path_outside_system]]:
         if os.path.exists(img_path_outside):
-            raise RuntimeError("Failed to remove old image file: " +
-                               img_path_outside)
+            pmb.helpers.mount.umount_all(args, chroot + "/mnt")
+            pmb.install.losetup.umount(args, img_path)
+            pmb.chroot.root(args, ["rm", img_path])
+            if os.path.exists(img_path_outside):
+                raise RuntimeError("Failed to remove old image file: " +
+                                   img_path_outside)
 
     # Make sure there is enough free space
-    size_mb = round(size / (1024**2))
+    size_mb = round((size_boot + size_system) / (1024**2))
     disk_data = os.statvfs(args.work)
     free = round((disk_data.f_bsize * disk_data.f_bavail) / (1024**2))
     if size_mb > free:
         raise RuntimeError("Not enough free space to create rootfs image! (free: " + str(free) + "M, required: " + str(size_mb) + "M)")
-    mb = str(size_mb) + "M"
 
-    # Create empty image file
-    logging.info("(native) create " + args.device + ".img (" + mb + ")")
+    # Create empty image files
     pmb.chroot.user(args, ["mkdir", "-p", "/home/pmos/rootfs"])
-    pmb.chroot.root(args, ["truncate", "-s", mb, img_path])
+    if not args.split:
+        size_mb_full = str(size_mb) + "M"
+        logging.info("(native) create " + args.device + ".img (" + size_mb_full + ")")
+        pmb.chroot.root(args, ["truncate", "-s", size_mb_full, img_path_full])
+    else:
+        size_mb_boot = str(round(size_boot / (1024**2))) + "M"
+        size_mb_system = str(round(size_system / (1024**2))) + "M"
+        logging.info("(native) create " + args.device + "-boot.img (" + size_mb_boot + ")")
+        pmb.chroot.root(args, ["truncate", "-s", size_mb_boot, img_path_boot])
+        logging.info("(native) create " + args.device + "-system.img (" + size_mb_system + ")")
+        pmb.chroot.root(args, ["truncate", "-s", size_mb_system, img_path_system])
 
     # Mount to /dev/install
-    logging.info("(native) mount /dev/install (" + args.device + ".img)")
-    pmb.install.losetup.mount(args, img_path)
-    device = pmb.install.losetup.device_by_back_file(args, img_path)
-    pmb.helpers.mount.bind_blockdevice(args, device, args.work +
-                                       "/chroot_native/dev/install")
+    mount_image_paths = list()
+    if not args.split:
+        mount_image_paths.append([img_path_full, "/dev/install"])
+    else:
+        mount_image_paths.append([img_path_boot, "/dev/install-boot"])
+        mount_image_paths.append([img_path_system, "/dev/install-system"])
+
+    for img_path, mount_point in mount_image_paths:
+        logging.info("(native) mount " + mount_point +
+                     " (" + os.path.basename(img_path) + ")")
+        pmb.install.losetup.mount(args, img_path)
+        device = pmb.install.losetup.device_by_back_file(args, img_path)
+        pmb.helpers.mount.bind_blockdevice(args, device, args.work +
+                                           "/chroot_native" + mount_point)
 
 
-def create(args, size):
+def create(args, size_boot, size_system):
     """
     Create /dev/install (the "install blockdevice").
 
-    :param size: of the whole image in bytes
+    :param size_boot: size of the boot partition in bytes
+    :param size_system: size of the system partition in bytes
     """
     pmb.helpers.mount.umount_all(
         args, args.work + "/chroot_native/dev/install")
     if args.sdcard:
         mount_sdcard(args)
     else:
-        create_and_mount_image(args, size)
+        create_and_mount_image(args, size_boot, size_system)

--- a/pmb/install/blockdevice.py
+++ b/pmb/install/blockdevice.py
@@ -79,24 +79,18 @@ def create_and_mount_image(args, size_boot, size_root):
     """
     # Short variables for paths
     chroot = args.work + "/chroot_native"
-    img_path_full = "/home/pmos/rootfs/" + args.device + ".img"
-    img_path_outside_full = chroot + img_path_full
-    img_path_boot = "/home/pmos/rootfs/" + args.device + "-boot.img"
-    img_path_outside_boot = chroot + img_path_boot
-    img_path_root = "/home/pmos/rootfs/" + args.device + "-root.img"
-    img_path_outside_root = chroot + img_path_root
+    img_path_prefix = "/home/pmos/rootfs/" + args.device
+    img_path_full = img_path_prefix + ".img"
+    img_path_boot = img_path_prefix + "-boot.img"
+    img_path_root = img_path_prefix + "-root.img"
 
     # Umount and delete existing images
-    for img_path, img_path_outside in {img_path_full: img_path_outside_full,
-                                       img_path_boot: img_path_outside_boot,
-                                       img_path_root: img_path_outside_root}.items():
-        if os.path.exists(img_path_outside):
+    for img_path in [img_path_full, img_path_boot, img_path_root]:
+        outside = chroot + img_path
+        if os.path.exists(outside):
             pmb.helpers.mount.umount_all(args, chroot + "/mnt")
             pmb.install.losetup.umount(args, img_path)
             pmb.chroot.root(args, ["rm", img_path])
-            if os.path.exists(img_path_outside):
-                raise RuntimeError("Failed to remove old image file: " +
-                                   img_path_outside)
 
     # Make sure there is enough free space
     size_mb = round((size_boot + size_root) / (1024**2))

--- a/pmb/install/format.py
+++ b/pmb/install/format.py
@@ -39,7 +39,7 @@ def format_and_mount_root(args):
     if not args.split:
         device = "/dev/installp2"
     else:
-        device = "/dev/install-system"
+        device = "/dev/install-root"
     if args.full_disk_encryption:
         logging.info("(native) format " + device + " (root, luks), mount to " +
                      mountpoint)
@@ -61,7 +61,7 @@ def format_and_mount_pm_crypt(args):
     elif not args.split:
         device = "/dev/installp2"
     else:
-        device = "/dev/install-system"
+        device = "/dev/install-root"
 
     # Format
     if not args.rsync:

--- a/pmb/install/format.py
+++ b/pmb/install/format.py
@@ -23,10 +23,7 @@ import pmb.chroot
 
 def format_and_mount_boot(args):
     mountpoint = "/mnt/install/boot"
-    if not args.split:
-        device = "/dev/installp1"
-    else:
-        device = "/dev/install-boot"
+    device = "/dev/installp1"
     logging.info("(native) format " + device + " (boot, ext2), mount to " +
                  mountpoint)
     pmb.chroot.root(args, ["mkfs.ext2", "-F", "-q", "-L", "pmOS_boot", device])
@@ -36,10 +33,7 @@ def format_and_mount_boot(args):
 
 def format_and_mount_root(args):
     mountpoint = "/dev/mapper/pm_crypt"
-    if not args.split:
-        device = "/dev/installp2"
-    else:
-        device = "/dev/install-root"
+    device = "/dev/installp2"
     if args.full_disk_encryption:
         logging.info("(native) format " + device + " (root, luks), mount to " +
                      mountpoint)
@@ -58,10 +52,8 @@ def format_and_mount_pm_crypt(args):
     # Block device
     if args.full_disk_encryption:
         device = "/dev/mapper/pm_crypt"
-    elif not args.split:
-        device = "/dev/installp2"
     else:
-        device = "/dev/install-root"
+        device = "/dev/installp2"
 
     # Format
     if not args.rsync:

--- a/pmb/install/format.py
+++ b/pmb/install/format.py
@@ -23,7 +23,10 @@ import pmb.chroot
 
 def format_and_mount_boot(args):
     mountpoint = "/mnt/install/boot"
-    device = "/dev/installp1"
+    if not args.split:
+        device = "/dev/installp1"
+    else:
+        device = "/dev/install-boot"
     logging.info("(native) format " + device + " (boot, ext2), mount to " +
                  mountpoint)
     pmb.chroot.root(args, ["mkfs.ext2", "-F", "-q", "-L", "pmOS_boot", device])
@@ -33,7 +36,10 @@ def format_and_mount_boot(args):
 
 def format_and_mount_root(args):
     mountpoint = "/dev/mapper/pm_crypt"
-    device = "/dev/installp2"
+    if not args.split:
+        device = "/dev/installp2"
+    else:
+        device = "/dev/install-system"
     if args.full_disk_encryption:
         logging.info("(native) format " + device + " (root, luks), mount to " +
                      mountpoint)
@@ -52,8 +58,10 @@ def format_and_mount_pm_crypt(args):
     # Block device
     if args.full_disk_encryption:
         device = "/dev/mapper/pm_crypt"
-    else:
+    elif not args.split:
         device = "/dev/installp2"
+    else:
+        device = "/dev/install-system"
 
     # Format
     if not args.rsync:

--- a/pmb/parse/arguments.py
+++ b/pmb/parse/arguments.py
@@ -321,7 +321,8 @@ def arguments():
     # Action: install
     install = sub.add_parser("install", help="set up device specific" +
                              " chroot and install to sdcard or image file")
-    install.add_argument("--sdcard", help="path to the sdcard device,"
+    group = install.add_mutually_exclusive_group()
+    group.add_argument("--sdcard", help="path to the sdcard device,"
                          " eg. /dev/mmcblk0")
     install.add_argument("--rsync", help="update the sdcard using rsync,"
                          " only works with --no-fde", action="store_true")
@@ -337,7 +338,7 @@ def arguments():
     install.add_argument("--flavor",
                          help="Specify kernel flavor to include in recovery"
                               " flashable zip", default=None)
-    install.add_argument("--android-recovery-zip",
+    group.add_argument("--android-recovery-zip",
                          help="generate TWRP flashable zip",
                          action="store_true", dest="android_recovery_zip")
     install.add_argument("--recovery-install-partition", default="system",
@@ -347,7 +348,7 @@ def arguments():
     install.add_argument("--recovery-no-kernel",
                          help="do not overwrite the existing kernel",
                          action="store_false", dest="recovery_flash_kernel")
-    install.add_argument("--split", help="install the boot and system partition"
+    group.add_argument("--split", help="install the boot and root partition"
                          " in separated image files", action="store_true")
 
     # Action: menuconfig

--- a/pmb/parse/arguments.py
+++ b/pmb/parse/arguments.py
@@ -323,7 +323,7 @@ def arguments():
                              " chroot and install to sdcard or image file")
     group = install.add_mutually_exclusive_group()
     group.add_argument("--sdcard", help="path to the sdcard device,"
-                         " eg. /dev/mmcblk0")
+                       " eg. /dev/mmcblk0")
     install.add_argument("--rsync", help="update the sdcard using rsync,"
                          " only works with --no-fde", action="store_true")
     install.add_argument("--cipher", help="cryptsetup cipher used to"
@@ -339,8 +339,8 @@ def arguments():
                          help="Specify kernel flavor to include in recovery"
                               " flashable zip", default=None)
     group.add_argument("--android-recovery-zip",
-                         help="generate TWRP flashable zip",
-                         action="store_true", dest="android_recovery_zip")
+                       help="generate TWRP flashable zip",
+                       action="store_true", dest="android_recovery_zip")
     install.add_argument("--recovery-install-partition", default="system",
                          help="partition to flash from recovery,"
                               " eg. external_sd",
@@ -349,7 +349,7 @@ def arguments():
                          help="do not overwrite the existing kernel",
                          action="store_false", dest="recovery_flash_kernel")
     group.add_argument("--split", help="install the boot and root partition"
-                         " in separated image files", action="store_true")
+                       " in separated image files", action="store_true")
 
     # Action: menuconfig
     menuconfig = sub.add_parser("menuconfig", help="run menuconfig on"

--- a/pmb/parse/arguments.py
+++ b/pmb/parse/arguments.py
@@ -347,6 +347,8 @@ def arguments():
     install.add_argument("--recovery-no-kernel",
                          help="do not overwrite the existing kernel",
                          action="store_false", dest="recovery_flash_kernel")
+    install.add_argument("--split", help="install the boot and system partition"
+                         " in separated image files", action="store_true")
 
     # Action: menuconfig
     menuconfig = sub.add_parser("menuconfig", help="run menuconfig on"

--- a/pmb/parse/arguments.py
+++ b/pmb/parse/arguments.py
@@ -324,6 +324,11 @@ def arguments():
     group = install.add_mutually_exclusive_group()
     group.add_argument("--sdcard", help="path to the sdcard device,"
                        " eg. /dev/mmcblk0")
+    group.add_argument("--split", help="install the boot and root partition"
+                       " in separated image files", action="store_true")
+    group.add_argument("--android-recovery-zip",
+                       help="generate TWRP flashable zip",
+                       action="store_true", dest="android_recovery_zip")
     install.add_argument("--rsync", help="update the sdcard using rsync,"
                          " only works with --no-fde", action="store_true")
     install.add_argument("--cipher", help="cryptsetup cipher used to"
@@ -338,9 +343,6 @@ def arguments():
     install.add_argument("--flavor",
                          help="Specify kernel flavor to include in recovery"
                               " flashable zip", default=None)
-    group.add_argument("--android-recovery-zip",
-                       help="generate TWRP flashable zip",
-                       action="store_true", dest="android_recovery_zip")
     install.add_argument("--recovery-install-partition", default="system",
                          help="partition to flash from recovery,"
                               " eg. external_sd",
@@ -348,8 +350,6 @@ def arguments():
     install.add_argument("--recovery-no-kernel",
                          help="do not overwrite the existing kernel",
                          action="store_false", dest="recovery_flash_kernel")
-    group.add_argument("--split", help="install the boot and root partition"
-                       " in separated image files", action="store_true")
 
     # Action: menuconfig
     menuconfig = sub.add_parser("menuconfig", help="run menuconfig on"


### PR DESCRIPTION
#### Overview
Add the  `--split` flag to the `pmbootstrap install` command which will create the boot and system partitions directly in separate images:
* `device-xxx-yyy-boot.img`
* `device-xxx-yyy-system.img`

With the `pmbootstrap export` you will get symlinks for the split files
#### Usage example (cli output)
```
$ yes | pmbootstrap -y install --no-fde --split
[23:28:56] *** (1/5) PREPARE NATIVE CHROOT ***
[23:28:57] *** (2/5) CREATE DEVICE ROOTFS ("samsung-i9070") ***
[23:29:02] (rootfs_samsung-i9070) install
[23:29:06] (rootfs_samsung-i9070) write /etc/os-release
[23:29:06] NOTE: Skipped initramfs generation (-s)!
[23:29:06]  *** SET LOGIN PASSWORD FOR: 'user' ***
New password: Retype new password: passwd: password updated successfully
[23:29:06] NOTE: No valid keymap specified for device
[23:29:09] *** (3/5) PREPARE INSTALL BLOCKDEVICE ***
[23:29:11] (native) create samsung-i9070-boot.img (27M)
[23:29:11] (native) create samsung-i9070-system.img (470M)
[23:29:11] (native) mount /dev/install-boot (samsung-i9070-boot.img)
[23:29:11] (native) mount /dev/install-system (samsung-i9070-system.img)
[23:29:11] (native) format /dev/install-system
[23:29:11] (native) mount /dev/install-system to /mnt/install
[23:29:11] (native) format /dev/install-boot (boot, ext2), mount to /mnt/install/boot
[23:29:12] *** (4/5) FILL INSTALL BLOCKDEVICE ***
[23:29:12] (native) copy rootfs_samsung-i9070 to /mnt/install/
[23:29:15] *** (5/5) FLASHING TO DEVICE ***
[23:29:15] Run the following to flash your installation to the target device:
[23:29:15] * pmbootstrap flasher flash_kernel
[23:29:15]   Flashes the kernel + initramfs to your device:
[23:29:15]   /home/drebrez/.local/var/pmbootstrap/chroot_rootfs_samsung-i9070/boot
[23:29:15] * If the above steps do not work, you can also create symlinks to the generated files with 'pmbootstrap export' and flash outside of pmbootstrap.
[23:29:15] Done
```
#### Changes
* `get_subpartitions_size` now returns the boot and the system partition sizes, not the full size
* `create_and_mount_image` works like before when no `--split` is specified, otherwise it will create 2 image files and bind them to `/dev/install-boot` and `/dev/install-system`
* `install_system_image` when `--split` is specified:
  * skip the creation of the partition table
  * skip mounting the subpartitions
  * skip the conversion to sparse image
  * skip the system flash information
* `symlinks` also create links to the boot and system image files

#### Tested
- [x] Creation of the full rootfs image (with and without fde)
- [x] Creation of the splitted boot and system image files (with and without fde)
- [x] Export the symlinks
- [x] Mount the boot and system image files and verify content
- [ ] Flash on device and verify

 

Close #1049


---
[x] Merge on GitHub (see <https://postmarketos.org/merge>)
