### PR TITLE
Only print 'pmbootstrap log' msg to stdout

### DIFF
--- a/pmb/__init__.py
+++ b/pmb/__init__.py
@@ -68,7 +68,8 @@ def main():
     except Exception as e:
         logging.info("ERROR: " + str(e))
         if os.path.exists(args.log):
-            logging.info("Run 'pmbootstrap log' for details.")
+            # Hint to read the log file (only gets printed to stdout)
+            print("Run 'pmbootstrap log' for details.")
         else:
             logging.info("Crashed before the log file was created.")
             logging.info("Running init again like the following gives more details:")


### PR DESCRIPTION
> Run 'pmbootstrap log' for details.

Prevent this message from being written to the log file that gets read with "pmbootstrap log". Because when the output of "pmbootstrap log" is pasted somewhere and people analyze it, the message sounds like this is *not* the output of "pmbootstrap log" (like it happened today in #postmarketOS).