### PR TITLE
Add support for a separate aports directory & repository.

### DIFF
--- a/pmb/config/__init__.py
+++ b/pmb/config/__init__.py
@@ -55,7 +55,7 @@ config_keys = ["ccache_size", "device", "extra_packages", "hostname", "jobs",
 # overriden on the commandline)
 defaults = {
     "alpine_version": "edge",  # alternatively: latest-stable
-    "aports": os.path.normpath(pmb_src + "/aports"),
+    "aports": os.path.expanduser("~") + "/.cache/pmbootstrap/aports",
     "ccache_size": "5G",
     # aes-xts-plain64 would be better, but this is not supported on LineageOS
     # kernel configs

--- a/pmb/parse/deviceinfo.py
+++ b/pmb/parse/deviceinfo.py
@@ -51,7 +51,7 @@ def deviceinfo(args, device=None):
         device = args.device
 
     if not os.path.exists(args.aports):
-        logging.fatal("Aports directory is missing")
+        logging.fatal("Aports directory is missing, expected: " + args.aports)
         logging.fatal("Please provide a path to the aports directory using the -p flag")
         raise RuntimeError("Aports directory missing")
 

--- a/pmb/parse/deviceinfo.py
+++ b/pmb/parse/deviceinfo.py
@@ -21,6 +21,9 @@ import os
 import pmb.config
 
 
+APORTS_GIT = "https://github.com/postmarketOS/aports.git"
+
+
 def sanity_check(info, path):
     # "flash_methods" is legacy
     if "flash_methods" in info:
@@ -52,7 +55,10 @@ def deviceinfo(args, device=None):
 
     if not os.path.exists(args.aports):
         logging.fatal("Aports directory is missing, expected: " + args.aports)
-        logging.fatal("Please provide a path to the aports directory using the -p flag")
+        logging.fatal("Please download them or provide a path to an"
+                      "alternative aports directory using the -p flag")
+        logging.fatal("Aports can be downloaded using the following command: ")
+        logging.fatal("    git clone {} {}".format(APORTS_GIT, args.aports))
         raise RuntimeError("Aports directory missing")
 
     aport = args.aports + "/device/device-" + device


### PR DESCRIPTION
Closes #383. Contains changes from #1454 (to avoid later rebasing)

NB, If Python 3.6 were supported, a much cleaner PEP-498 could be used:

```
        logging.fatal(f"    git clone {APORTS_GIT} {args.aports}")
```
---
[x] Merge on GitHub (see <https://postmarketos.org/merge>)
