### PR TITLE
gcc-*: fix compiling in strict mode [skip ci]

### DIFF
--- a/aports/cross/gcc-aarch64/APKBUILD
+++ b/aports/cross/gcc-aarch64/APKBUILD
@@ -4,7 +4,6 @@
 
 CTARGET_ARCH=aarch64
 CTARGET="$(arch_to_hostspec ${CTARGET_ARCH})"
-CBUILDROOT="/usr/$CTARGET"
 LANG_OBJC=false
 LANG_JAVA=false
 LANG_GO=false
@@ -12,40 +11,16 @@ LANG_FORTRAN=false
 LANG_ADA=false
 options="!strip !tracedeps"
 
-# Wrap the package function, to make the resulting package
-# lazy-reproducible
-package() {
-    # Repack the *.a files to be reproducible (see #64)
-    _temp="$_builddir"/_reproducible-patch
-    cd "$_builddir"
-    for f in $(find -name '*.a'); do
-        # Copy to a temporary folder
-        echo "Repack $f to be reproducible"
-        mkdir -p "$_temp"
-        cd "$_temp"
-        cp "$_builddir"/"$f" .
+# abuild doesn't try to tries to install "build-base-$CTARGET_ARCH"
+# when this variable matches "no*"
+BOOTSTRAP="nobuildbase"
 
-        # Repack with a sorted file order
-        ar x *.a
-        rm *.a
-        ar r sorted.a $(find -name '*.o' | sort)
+# abuild will only cross compile when this variable is set, but it
+# needs to find a valid package database in there for dependency
+# resolving, so we set it to /.
+CBUILDROOT="/"
 
-        # Copy back and clean up
-        cp -v sorted.a "$_builddir"/"$f"
-        cd ..
-        rm -r "$_temp"
-    done
-
-    # Unmodified package function from the gcc APKBUILD
-    _package
-
-    # Workaround for: postmarketOS/binary-package-repo#1
-    echo "Replacing hardlinks with symlinks"
-    rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
-    ln -s -v /usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
-    rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
-    ln -s -v /usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
-}
+_cross_configure="--disable-bootstrap --with-sysroot=/usr/$CTARGET"
 
 pkgname="gcc-aarch64"
 pkgver=6.4.0
@@ -287,7 +262,6 @@ prepare() {
 build() {
 	local _arch_configure=
 	local _libc_configure=
-	local _cross_configure=
 	local _bootstrap_configure=
 	local _symvers=
 
@@ -325,8 +299,6 @@ build() {
 		;;
 	esac
 
-	[ "$CBUILD" != "$CHOST"   ] && _cross_configure="--disable-bootstrap"
-	[ "$CHOST"  != "$CTARGET" ] && _cross_configure="--disable-bootstrap --with-sysroot=$CBUILDROOT"
 
 	case "$BOOTSTRAP" in
 	nolibc)	_bootstrap_configure="--with-newlib --disable-shared --enable-threads=no" ;;
@@ -382,7 +354,7 @@ build() {
 	make
 }
 
-_package() {
+package() {
 	cd "$_builddir"
 	make -j1 DESTDIR="${pkgdir}" install
 

--- a/aports/cross/gcc-armhf/APKBUILD
+++ b/aports/cross/gcc-armhf/APKBUILD
@@ -4,7 +4,6 @@
 
 CTARGET_ARCH=armhf
 CTARGET="$(arch_to_hostspec ${CTARGET_ARCH})"
-CBUILDROOT="/usr/$CTARGET"
 LANG_OBJC=false
 LANG_JAVA=false
 LANG_GO=false
@@ -12,40 +11,16 @@ LANG_FORTRAN=false
 LANG_ADA=false
 options="!strip !tracedeps"
 
-# Wrap the package function, to make the resulting package
-# lazy-reproducible
-package() {
-    # Repack the *.a files to be reproducible (see #64)
-    _temp="$_builddir"/_reproducible-patch
-    cd "$_builddir"
-    for f in $(find -name '*.a'); do
-        # Copy to a temporary folder
-        echo "Repack $f to be reproducible"
-        mkdir -p "$_temp"
-        cd "$_temp"
-        cp "$_builddir"/"$f" .
+# abuild doesn't try to tries to install "build-base-$CTARGET_ARCH"
+# when this variable matches "no*"
+BOOTSTRAP="nobuildbase"
 
-        # Repack with a sorted file order
-        ar x *.a
-        rm *.a
-        ar r sorted.a $(find -name '*.o' | sort)
+# abuild will only cross compile when this variable is set, but it
+# needs to find a valid package database in there for dependency
+# resolving, so we set it to /.
+CBUILDROOT="/"
 
-        # Copy back and clean up
-        cp -v sorted.a "$_builddir"/"$f"
-        cd ..
-        rm -r "$_temp"
-    done
-
-    # Unmodified package function from the gcc APKBUILD
-    _package
-
-    # Workaround for: postmarketOS/binary-package-repo#1
-    echo "Replacing hardlinks with symlinks"
-    rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
-    ln -s -v /usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
-    rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
-    ln -s -v /usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
-}
+_cross_configure="--disable-bootstrap --with-sysroot=/usr/$CTARGET"
 
 pkgname="gcc-armhf"
 pkgver=6.4.0
@@ -287,7 +262,6 @@ prepare() {
 build() {
 	local _arch_configure=
 	local _libc_configure=
-	local _cross_configure=
 	local _bootstrap_configure=
 	local _symvers=
 
@@ -325,8 +299,6 @@ build() {
 		;;
 	esac
 
-	[ "$CBUILD" != "$CHOST"   ] && _cross_configure="--disable-bootstrap"
-	[ "$CHOST"  != "$CTARGET" ] && _cross_configure="--disable-bootstrap --with-sysroot=$CBUILDROOT"
 
 	case "$BOOTSTRAP" in
 	nolibc)	_bootstrap_configure="--with-newlib --disable-shared --enable-threads=no" ;;
@@ -382,7 +354,7 @@ build() {
 	make
 }
 
-_package() {
+package() {
 	cd "$_builddir"
 	make -j1 DESTDIR="${pkgdir}" install
 

--- a/aports/cross/gcc-x86_64/APKBUILD
+++ b/aports/cross/gcc-x86_64/APKBUILD
@@ -4,7 +4,6 @@
 
 CTARGET_ARCH=x86_64
 CTARGET="$(arch_to_hostspec ${CTARGET_ARCH})"
-CBUILDROOT="/usr/$CTARGET"
 LANG_OBJC=false
 LANG_JAVA=false
 LANG_GO=false
@@ -12,40 +11,16 @@ LANG_FORTRAN=false
 LANG_ADA=false
 options="!strip !tracedeps"
 
-# Wrap the package function, to make the resulting package
-# lazy-reproducible
-package() {
-    # Repack the *.a files to be reproducible (see #64)
-    _temp="$_builddir"/_reproducible-patch
-    cd "$_builddir"
-    for f in $(find -name '*.a'); do
-        # Copy to a temporary folder
-        echo "Repack $f to be reproducible"
-        mkdir -p "$_temp"
-        cd "$_temp"
-        cp "$_builddir"/"$f" .
+# abuild doesn't try to tries to install "build-base-$CTARGET_ARCH"
+# when this variable matches "no*"
+BOOTSTRAP="nobuildbase"
 
-        # Repack with a sorted file order
-        ar x *.a
-        rm *.a
-        ar r sorted.a $(find -name '*.o' | sort)
+# abuild will only cross compile when this variable is set, but it
+# needs to find a valid package database in there for dependency
+# resolving, so we set it to /.
+CBUILDROOT="/"
 
-        # Copy back and clean up
-        cp -v sorted.a "$_builddir"/"$f"
-        cd ..
-        rm -r "$_temp"
-    done
-
-    # Unmodified package function from the gcc APKBUILD
-    _package
-
-    # Workaround for: postmarketOS/binary-package-repo#1
-    echo "Replacing hardlinks with symlinks"
-    rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
-    ln -s -v /usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
-    rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
-    ln -s -v /usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
-}
+_cross_configure="--disable-bootstrap --with-sysroot=/usr/$CTARGET"
 
 pkgname="gcc-x86_64"
 pkgver=6.4.0
@@ -287,7 +262,6 @@ prepare() {
 build() {
 	local _arch_configure=
 	local _libc_configure=
-	local _cross_configure=
 	local _bootstrap_configure=
 	local _symvers=
 
@@ -325,8 +299,6 @@ build() {
 		;;
 	esac
 
-	[ "$CBUILD" != "$CHOST"   ] && _cross_configure="--disable-bootstrap"
-	[ "$CHOST"  != "$CTARGET" ] && _cross_configure="--disable-bootstrap --with-sysroot=$CBUILDROOT"
 
 	case "$BOOTSTRAP" in
 	nolibc)	_bootstrap_configure="--with-newlib --disable-shared --enable-threads=no" ;;
@@ -382,7 +354,7 @@ build() {
 	make
 }
 
-_package() {
+package() {
 	cd "$_builddir"
 	make -j1 DESTDIR="${pkgdir}" install
 

--- a/pmb/aportgen/core.py
+++ b/pmb/aportgen/core.py
@@ -105,7 +105,7 @@ def rewrite(args, pkgname, path_original, fields={}, replace_pkgname=None,
 
             # Replace simple
             for pattern, replacement in replace_simple.items():
-                if fnmatch.fnmatch(line, pattern):
+                if fnmatch.fnmatch(line, pattern + "\n"):
                     line = replacement
                     if replacement:
                         line += "\n"

--- a/pmb/aportgen/gcc.py
+++ b/pmb/aportgen/gcc.py
@@ -49,7 +49,6 @@ def generate(args, pkgname):
 
     below_header = "CTARGET_ARCH=" + arch + """
         CTARGET="$(arch_to_hostspec ${CTARGET_ARCH})"
-        CBUILDROOT="/usr/$CTARGET"
         LANG_OBJC=false
         LANG_JAVA=false
         LANG_GO=false
@@ -57,41 +56,22 @@ def generate(args, pkgname):
         LANG_ADA=false
         options="!strip !tracedeps"
 
-        # Wrap the package function, to make the resulting package
-        # lazy-reproducible
-        package() {
-            # Repack the *.a files to be reproducible (see #64)
-            _temp="$_builddir"/_reproducible-patch
-            cd "$_builddir"
-            for f in $(find -name '*.a'); do
-                # Copy to a temporary folder
-                echo "Repack $f to be reproducible"
-                mkdir -p "$_temp"
-                cd "$_temp"
-                cp "$_builddir"/"$f" .
+        # abuild doesn't try to tries to install "build-base-$CTARGET_ARCH"
+        # when this variable matches "no*"
+        BOOTSTRAP="nobuildbase"
 
-                # Repack with a sorted file order
-                ar x *.a
-                rm *.a
-                ar r sorted.a $(find -name '*.o' | sort)
+        # abuild will only cross compile when this variable is set, but it
+        # needs to find a valid package database in there for dependency
+        # resolving, so we set it to /.
+        CBUILDROOT="/"
 
-                # Copy back and clean up
-                cp -v sorted.a "$_builddir"/"$f"
-                cd ..
-                rm -r "$_temp"
-            done
-
-            # Unmodified package function from the gcc APKBUILD
-            _package
-
-            # Workaround for: postmarketOS/binary-package-repo#1
-            echo "Replacing hardlinks with symlinks"
-            rm -v "$pkgdir"/usr/bin/"$CTARGET"-c++
-            ln -s -v /usr/bin/"$CTARGET"-g++ "$pkgdir"/usr/bin/"$CTARGET"-c++
-            rm -v "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
-            ln -s -v /usr/bin/"$CTARGET"-gcc "$pkgdir"/usr/bin/"$CTARGET"-gcc-"$pkgver"
-        }
+        _cross_configure="--disable-bootstrap --with-sysroot=/usr/$CTARGET"
     """
+
+    # Download links
+    link1 = ("gcc.gnu.org/pub/gcc/releases/gcc-${_pkgbase:-$pkgver}/gcc-"
+             "${_pkgbase:-$pkgver}.tar.xz")
+    link2 = "sourceware.org/pub/java/ecj-4.9.jar"
 
     replace_simple = {
         # Do not package libstdc++, do not add "g++-$ARCH" here (already
@@ -99,8 +79,14 @@ def generate(args, pkgname):
         # pmbootstrap picks it up properly).
         '*subpackages="$subpackages libstdc++:libcxx:*': None,
 
-        # Rename package to _package, so we can wrap it (see above)
-        '*package() {*': "_package() {"
+        # We set the cross_configure variable at the beginning, so it does not
+        # use CBUILDROOT as sysroot. In the original APKBUILD this is a local
+        # variable, but we make it a global one.
+        '*_cross_configure=*': None,
+
+        # Fix download links by replacing ftp:// with http://
+        'source="ftp://' + link1: 'source="http://' + link1,
+        "\tftp://" + link2: "\thttp://" + link2
     }
 
     pmb.aportgen.core.rewrite(args, pkgname, "main/gcc", fields,

--- a/pmb/aportgen/gcc.py
+++ b/pmb/aportgen/gcc.py
@@ -68,11 +68,6 @@ def generate(args, pkgname):
         _cross_configure="--disable-bootstrap --with-sysroot=/usr/$CTARGET"
     """
 
-    # Download links
-    link1 = ("gcc.gnu.org/pub/gcc/releases/gcc-${_pkgbase:-$pkgver}/gcc-"
-             "${_pkgbase:-$pkgver}.tar.xz")
-    link2 = "sourceware.org/pub/java/ecj-4.9.jar"
-
     replace_simple = {
         # Do not package libstdc++, do not add "g++-$ARCH" here (already
         # did that explicitly in the subpackages variable above, so
@@ -83,10 +78,6 @@ def generate(args, pkgname):
         # use CBUILDROOT as sysroot. In the original APKBUILD this is a local
         # variable, but we make it a global one.
         '*_cross_configure=*': None,
-
-        # Fix download links by replacing ftp:// with http://
-        'source="ftp://' + link1: 'source="http://' + link1,
-        "\tftp://" + link2: "\thttp://" + link2
     }
 
     pmb.aportgen.core.rewrite(args, pkgname, "main/gcc", fields,


### PR DESCRIPTION
Due to changes in abuild, our `gcc-armhf` etc. packages did not build
when using strict mode (i.e. `pmbootstrap build --strict gcc-armhf`)
anymore.

### Changes
* Set `CBUILDDIR=/`, so apk can read a valid package index from there
* Directly set `_cross_configure`, so it does not use CBUILDDIR anymore
* Set `BOOTSTRAP="nobuildbase"` to prevent apk from installing
  `build-base-armhf` etc. (these don't exist in pmOS)
* Remove legacy code for lazy reproducible builds that wrapped
  `package()`
* Fix download links by replacing ftp:// with http:// (also made a PR
  to fix this upstream: https://github.com/alpinelinux/aports/pull/4199)

### How to test
```
$ pmbootstrap build gcc-armhf --force
$ pmbootstrap build hello-world --force --arch=armhf
```

Fixes #1458.

NOTE: Travis fails, because building the packages takes too long for Travis.

---
[x] Merge on GitHub (see <https://postmarketos.org/merge>)
