### PR TITLE
main/linux-postmarketos-qcom: update to latest revision

### DIFF
--- a/aports/main/linux-postmarketos-qcom/APKBUILD
+++ b/aports/main/linux-postmarketos-qcom/APKBUILD
@@ -4,7 +4,7 @@ _config="config-${_flavor}.${CARCH}"
 pkgname=linux-${_flavor}
 
 pkgver=4.17_rc3
-pkgrel=1
+pkgrel=2
 
 arch="armhf"
 pkgdesc="Kernel close to mainline with extra patches for Qualcomm devices"

--- a/aports/main/linux-postmarketos-qcom/APKBUILD
+++ b/aports/main/linux-postmarketos-qcom/APKBUILD
@@ -13,7 +13,7 @@ depends=""
 makedepends="dtbtool perl sed installkernel bash gmp-dev bc linux-headers elfutils-dev libressl-dev file bison flex"
 options="!strip !check !tracedeps"
 install=
-_commit="ad0dd87cc34c8ed7ac4cd04465d7e75c71dd8fe3"
+_commit="5f53b10c2e8bb79dccccb0e849be6fe5f2d32822"
 source="
 	linux-${_commit}.tar.gz::https://github.com/postmarketOS/linux/archive/${_commit}.tar.gz
 	config-${_flavor}.armhf
@@ -183,5 +183,5 @@ dev() {
 		done
 	fi
 }
-sha512sums="d2396e95e5f6e6e95a0c55d6dbe93b2c157db793d068039eba0d8678ef4348fcb8575e7960809941cd3d60f864dbee384b05d9a99b5971bd7b10ce85fa2dae6e  linux-ad0dd87cc34c8ed7ac4cd04465d7e75c71dd8fe3.tar.gz
+sha512sums="8c46beb8cf984a582e628cad77021f199e87bdf9d96bb9ef7aaf39e1c430ec58b59f60f590a3cf446dd0f337cc0838699d5a98786c0dd6b8f53f1a13950c92e2  linux-5f53b10c2e8bb79dccccb0e849be6fe5f2d32822.tar.gz
 7a57f8599be1cb99b4107e02747e21959cd6ba2bb81e5c0ce7554d642b7242bfd696674c13016a22383b80ccb8b96e00556d89cdab2341e2ae4734e5db4f15b8  config-postmarketos-qcom.armhf"


### PR DESCRIPTION
adds support for sdcard on sirius.

---
[x] Merge on GitHub (see <https://postmarketos.org/merge>)
