### PR TITLE
Add samsung-klte mainline kernel

### DIFF
--- a/aports/device/device-samsung-klte/APKBUILD
+++ b/aports/device/device-samsung-klte/APKBUILD
@@ -1,13 +1,17 @@
 pkgname="device-samsung-klte"
 pkgdesc="Samsung Galaxy S5"
-pkgver=0.1
-pkgrel=3
+pkgver=0.2
+pkgrel=0
 url="https://postmarketos.org"
 license="MIT"
 arch="noarch"
 options="!check"
-depends="postmarketos-base linux-samsung-klte mkbootimg msm-fb-refresher"
+depends="postmarketos-base mkbootimg msm-fb-refresher"
 makedepends="devicepkg-dev"
+subpackages="
+	$pkgname-kernel-downstream:kernel_downstream
+	$pkgname-kernel-mainline:kernel_mainline
+"
 source="deviceinfo"
 
 build() {
@@ -16,6 +20,18 @@ build() {
 
 package() {
 	devicepkg_package $startdir $pkgname
+}
+
+kernel_downstream() {
+	pkgdesc="Display and touchscreen works (see device table for details)"
+	depends="linux-samsung-klte"
+	mkdir "$subpkgdir"
+}
+
+kernel_mainline() {
+	pkgdesc="For kernel development only (most features aren't working)"
+	depends="linux-postmarketos-qcom"
+	mkdir "$subpkgdir"
 }
 
 sha512sums="fc39550299d6ffee33c1b984671a91a5da9a4f24db5994cfd8650a75f96416bc30c3b169353ea3939c765df6a5801ee9647808c82d46a00190a0c1db44708b73  deviceinfo"

--- a/aports/main/linux-postmarketos-qcom/APKBUILD
+++ b/aports/main/linux-postmarketos-qcom/APKBUILD
@@ -4,7 +4,7 @@ _config="config-${_flavor}.${CARCH}"
 pkgname=linux-${_flavor}
 
 pkgver=4.17_rc3
-pkgrel=2
+pkgrel=3
 
 arch="armhf"
 pkgdesc="Kernel close to mainline with extra patches for Qualcomm devices"
@@ -13,7 +13,7 @@ depends=""
 makedepends="dtbtool perl sed installkernel bash gmp-dev bc linux-headers elfutils-dev libressl-dev file bison flex"
 options="!strip !check !tracedeps"
 install=
-_commit="5f53b10c2e8bb79dccccb0e849be6fe5f2d32822"
+_commit="09efb4857f1a4119eced855912043817bd96e064"
 source="
 	linux-${_commit}.tar.gz::https://github.com/postmarketOS/linux/archive/${_commit}.tar.gz
 	config-${_flavor}.armhf
@@ -183,5 +183,5 @@ dev() {
 		done
 	fi
 }
-sha512sums="8c46beb8cf984a582e628cad77021f199e87bdf9d96bb9ef7aaf39e1c430ec58b59f60f590a3cf446dd0f337cc0838699d5a98786c0dd6b8f53f1a13950c92e2  linux-5f53b10c2e8bb79dccccb0e849be6fe5f2d32822.tar.gz
+sha512sums="02fd136d24914e30decd207c3b2e0168cc9d6e4a0fc981abf8d537cd95c70583f5239d0dc7f2ae94a2ddd2ba82d822933159167801a035731a24aa1300c5ceec  linux-09efb4857f1a4119eced855912043817bd96e064.tar.gz
 7a57f8599be1cb99b4107e02747e21959cd6ba2bb81e5c0ce7554d642b7242bfd696674c13016a22383b80ccb8b96e00556d89cdab2341e2ae4734e5db4f15b8  config-postmarketos-qcom.armhf"


### PR DESCRIPTION
Changes:
- `device-samsung-klte` with both downstream and mainline kernel subpackages
- `linux-postmarketos-qcom` updated to last commit

What works in mainline kernel:
- internal SD card
- volume and home key buttons
- usb network

---
[x] Merge on GitHub (see <https://postmarketos.org/merge>)
