### PR TITLE
Add support to different deviceinfo variables in mainline/downstream subpackages

### DIFF
--- a/aports/main/devicepkg-dev/APKBUILD
+++ b/aports/main/devicepkg-dev/APKBUILD
@@ -1,5 +1,5 @@
 pkgname="devicepkg-dev"
-pkgver=0.2
+pkgver=0.3
 pkgrel=0
 pkgdesc="Provides default device package functions"
 url="https://github.com/postmarketOS"
@@ -8,6 +8,7 @@ license="MIT"
 source="
 	devicepkg_build.sh
 	devicepkg_package.sh
+	devicepkg_subpackage.sh
 "
 
 package() {
@@ -15,6 +16,9 @@ package() {
 		"$pkgdir/usr/bin/devicepkg_build"
 	install -Dm755 "$srcdir/devicepkg_package.sh" \
 		"$pkgdir/usr/bin/devicepkg_package"
+	install -Dm755 "$srcdir/devicepkg_subpackage.sh" \
+		"$pkgdir/usr/bin/devicepkg_subpackage"
 }
-sha512sums="638d50e6388eabf0da6bf0cff2fe9719ad8a808946f0077228db57fa13a26d9eeb39c1f2689c9a6f93ff9b3bcfdcfb7c358b180bba90e5bba8b9a9e78d25ed18  devicepkg_build.sh
-c732792596f56860f6ab9ddd53b9a7a80224400dd20097b20cebe17a6e7330e9178783f09db16132a28a555f83e29ef3643bfe069638b62998912a9a7ffefdc0  devicepkg_package.sh"
+sha512sums="a2348db1d0a017664fc27d7c3a8766df309ad31092510193e88c5d63f7fd7d1de02c09c33af0a16267307593ab6fa44d9b8691b0d601157ab6d116783072e9f6  devicepkg_build.sh
+7173babf7beefce69085848a03477781ea183f7aaead04de5e85574f206b6a304873a92de0a5b563f7613dc6bfa04b30a05c7728373cd22774bcd7bd12c559a0  devicepkg_package.sh
+aa677624d24490a2ca4a61d25f56a6ad06ec9a24aeb32e65a75d5a579285c88c6b0e4657fb70f57ce4022d9aaa3a5998b96f0143ce928c93499ea8e680034a09  devicepkg_subpackage.sh"

--- a/aports/main/devicepkg-dev/devicepkg_build.sh
+++ b/aports/main/devicepkg-dev/devicepkg_build.sh
@@ -4,7 +4,7 @@ pkgname=$2
 
 if [ -z "$startdir" ] || [ -z "$pkgname" ]; then
 	echo "ERROR: missing argument!"
-	echo "Please call devicepkg_default_build() with \$startdir and \$pkgname as arguments."
+	echo "Please use $0 with \$startdir and \$pkgname as arguments."
 	exit 1
 fi
 

--- a/aports/main/devicepkg-dev/devicepkg_package.sh
+++ b/aports/main/devicepkg-dev/devicepkg_package.sh
@@ -4,7 +4,7 @@ pkgname=$2
 
 if [ -z "$startdir" ] || [ -z "$pkgname" ]; then
 	echo "ERROR: missing argument!"
-	echo "Please call devicepkg_default_package() with \$startdir and \$pkgname as arguments."
+	echo "Please use $0 with \$startdir and \$pkgname as arguments."
 	exit 1
 fi
 
@@ -18,8 +18,11 @@ if [ ! -f "$srcdir/deviceinfo" ]; then
 	exit 1
 fi
 
-install -Dm644 "$srcdir/deviceinfo" \
-	"$pkgdir/etc/deviceinfo"
+if ( grep -qE "^deviceinfo_kernel_cmdline=" "$srcdir/deviceinfo" ) || \
+	( ! grep -qE "^deviceinfo_kernel_cmdline" "$srcdir/deviceinfo" ); then
+	install -Dm644 "$srcdir/deviceinfo" \
+		"$pkgdir/etc/deviceinfo"
+fi
 
 if [ -f "$srcdir/90-$pkgname.rules" ]; then
 	install -Dm644 "$srcdir/90-$pkgname.rules" \

--- a/aports/main/devicepkg-dev/devicepkg_subpackage.sh
+++ b/aports/main/devicepkg-dev/devicepkg_subpackage.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+startdir=$1
+subpkgname=$2
+kernel=$(echo $subpkgname | sed -n "s/.*-kernel-\(.*\)/\1/p")
+
+if [ -z "$startdir" ] || [ -z "$subpkgname" ]; then
+	echo "ERROR: missing argument!"
+	echo "Please use $0 with \$startdir and \$subpkgname as arguments."
+	exit 1
+fi
+
+srcdir="$startdir/src"
+subpkgdir="$startdir/pkg/$subpkgname"
+
+if [ ! -f "$srcdir/deviceinfo" ]; then
+	echo "ERROR: deviceinfo file missing!"
+	exit 1
+fi
+
+if grep -qE "^deviceinfo_kernel_cmdline=" "$srcdir/deviceinfo"; then
+	echo "ERROR: deviceinfo contains a generic kernel cmdline variable!"
+	exit 1
+fi
+
+if grep -q "deviceinfo_kernel_cmdline_$kernel" "$srcdir/deviceinfo"; then
+	sed "s/deviceinfo_kernel_cmdline_$kernel/deviceinfo_kernel_cmdline/g" "$srcdir/deviceinfo" | \
+		sed ":a;N;s/deviceinfo_kernel_cmdline_.*\n//g;ba" > "$srcdir/deviceinfo_$kernel"
+	install -Dm644 "$srcdir/deviceinfo_$kernel" \
+		"$subpkgdir/etc/deviceinfo"
+else
+	echo "ERROR: deviceinfo doesn't contain the \"deviceinfo_kernel_cmdline_$kernel\" variable!"
+	exit 1
+fi


### PR DESCRIPTION
#### Changes:
- New version of `devicepkg-dev` with changes described in https://github.com/postmarketOS/pmbootstrap/issues/1368#issuecomment-387809557

#### How to test:
edit `deviceinfo` file of `device-samsung-klte` and replace the `deviceinfo_kernel_cmdline` line with:
```
deviceinfo_kernel_cmdline_downstream="androidboot.boot_recovery=1"
deviceinfo_kernel_cmdline_mainline="console=ttyMSM0,115200,n8 PMOS_NO_OUTPUT_REDIRECT"
```
then run:
```
pmbootstrap -y zap
pmbootstrap build devicepkg-dev --force --arch armhf

# Test device with both cmdlines
pmbootstrap build device-samsung-klte --force --arch armhf

pmbootstrap chroot -b -- find /home/pmos/build/pkg/
# output should contain the deviceinfo file in both subpackages and not in the device package

pmbootstrap chroot -b -- cat /home/pmos/build/pkg/device-samsung-klte-kernel-downstream/etc/deviceinfo
# output should contain the line: deviceinfo_kernel_cmdline="androidboot.boot_recovery=1"

pmbootstrap chroot -b -- cat /home/pmos/build/pkg/device-samsung-klte-kernel-mainline/etc/deviceinfo
# output should contain the line: deviceinfo_kernel_cmdline="console=ttyMSM0,115200,n8 PMOS_NO_OUTPUT_REDIRECT"


# Test device with normal cmdline
pmbootstrap build device-samsung-maguro --force --arch armhf

pmbootstrap chroot -b -- find /home/pmos/build/pkg/
# output should contain the deviceinfo file in the device package as usual

pmbootstrap chroot -b -- cat /home/pmos/build/pkg/device-samsung-maguro/etc/deviceinfo
# output should contain the exact content as the source file


# Test device without cmdline
pmbootstrap build device-samsung-i9070 --force --arch armhf

pmbootstrap chroot -b -- find /home/pmos/build/pkg/
# output should contain the deviceinfo file in the device package as usual

pmbootstrap chroot -b -- cat /home/pmos/build/pkg/device-samsung-i9070/etc/deviceinfo
# output should contain the exact content as the source file
```

Closes: #1368

---
[x] Merge on GitHub (see <https://postmarketos.org/merge>)
