### PR TITLE
[wip] Plasma mobile ofono integration

### DIFF
--- a/aports/kde/plasma-phone-components/APKBUILD
+++ b/aports/kde/plasma-phone-components/APKBUILD
@@ -2,14 +2,14 @@
 # Maintainer Bart Ribbers <bribbers@disroot.org>
 pkgname=plasma-phone-components
 pkgver=0_git20180221
-pkgrel=2
+pkgrel=3
 _commit="9222d501fa6b86b93382e0dd1a7c965668960cee"
 pkgdesc="Modules providing phone functionality for Plasma"
 arch="all"
 url="https://community.kde.org/Plasma/Mobile"
 license="GPL3"
 depends="desktop-file-utils qt5-qtgraphicaleffects kactivities qt5-qtquickcontrols2 qt5-qtquickcontrols
-		plasma-pa plasma-nm upower"
+		plasma-pa plasma-nm upower libqofono"
 makedepends="extra-cmake-modules kpeople-dev qt5-qtdeclarative-dev kactivities-dev
 			 plasma-framework-dev kservice-dev kdeclarative-dev ki18n-dev kio-dev kcoreaddons-dev
 			 kconfig-dev kbookmarks-dev kwidgetsaddons-dev kcompletion-dev kitemviews-dev

--- a/aports/main/libqofono/APKBUILD
+++ b/aports/main/libqofono/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Bhushan Shah <bshah@kde.org>
+# Maintainer: Bhushan Shah <bshah@kde.org>
+pkgname=libqofono
+pkgver=0.92
+pkgrel=0
+pkgdesc="A library for accessing the ofono daemon, and a Qt declarative plugin for it."
+url="https://git.merproject.org/mer-core/libqofono/"
+arch="all"
+license="LGPL-2.0"
+depends=""
+depends_dev="qt5-qtbase-dev qt5-qtxmlpatterns-dev qt5-qtdeclarative-dev"
+makedepends="$depends_dev"
+install=""
+subpackages="$pkgname-dev"
+source="https://git.merproject.org/mer-core/$pkgname/-/archive/$pkgver/$pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+# the tests are marked as autotest but they require ofono running
+# along with ofono-phonesim, which is overall complext setup
+options="!check"
+
+build() {
+	cd "$builddir"
+	qmake-qt5
+	make
+}
+
+package() {
+	cd "$builddir"
+	make INSTALL_ROOT="$pkgdir" install
+	# remove the installed tests xml file
+	rm -r "$pkgdir"/opt
+	rm -r "$pkgdir"/usr/lib/libqofono-qt5/tests/
+}
+
+sha512sums="955a044b15d9f09087c6d0a60395b40fc3a1b1ed203912db414f9faae8dc26488ded535fd1daf1a0d0579a36511127eb5a925ee214f4df4fc631cee7ba255102  libqofono-0.92.tar.gz"


### PR DESCRIPTION
Remaining is packaging work to get calling working with ofono, I'll mark it !wip when done.

- [x] show network status in top bar of plasma mobile

Tested by @MartijnBraam:
![img_20180517_184106](https://user-images.githubusercontent.com/1061944/40192865-3392f352-5a23-11e8-9def-cd74744932a1.jpg)


- [ ] telepathy-ofono and friends for plasma mobile
- [ ] Calling through ofono phonesim driver (in QEMU)
- [ ] ofono patches for calling in QMI based devices

Maybe I should create 4 different PR though? opinions?

---
[ ] Merge on GitHub (see <https://postmarketos.org/merge>)
