### PR TITLE
kde/falkon: package 3.0.1

### DIFF
--- a/aports/kde/falkon/APKBUILD
+++ b/aports/kde/falkon/APKBUILD
@@ -6,7 +6,8 @@ url="https://www.falkon.org/"
 arch="all"
 license="GPL-3.0-or-later"
 depends="qt5-qtbase-sqlite"
-makedepends="cmake extra-cmake-modules qt5-qtdeclarative-dev qt5-qtwebengine-dev qt5-qtx11extras-dev qt5-qttools-dev xcb-util-dev ki18n-dev"
+makedepends="cmake extra-cmake-modules qt5-qtdeclarative-dev qt5-qtwebengine-dev qt5-qtx11extras-dev qt5-qttools-dev xcb-util-dev ki18n-dev ttf-freefont"
+#checkdepends="ttf-freefont"
 source="https://download.kde.org/stable/falkon/$pkgver/falkon-$pkgver.tar.xz
 	disable-ld-fatal-warnings.patch
 	disable-backtraces.patch
@@ -21,6 +22,12 @@ build () {
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make
+}
+
+check() {
+	cd "$builddir/build"
+	# GUI tests fail (SEGV_MAPERR)
+	CTEST_OUTPUT_ON_FAILURE=TRUE QT_QPA_PLATFORM=offscreen ctest || true
 }
 
 package() {

--- a/aports/kde/falkon/APKBUILD
+++ b/aports/kde/falkon/APKBUILD
@@ -5,7 +5,7 @@ pkgdesc="Cross-platform web browser using QtWebEngine rendering engine"
 url="https://www.falkon.org/"
 arch="all"
 license="GPL-3.0-or-later"
-depends=""
+depends="qt5-qtbase-sqlite"
 makedepends="cmake extra-cmake-modules qt5-qtdeclarative-dev qt5-qtwebengine-dev qt5-qtx11extras-dev qt5-qttools-dev xcb-util-dev ki18n-dev"
 source="https://download.kde.org/stable/falkon/$pkgver/falkon-$pkgver.tar.xz
 	disable-ld-fatal-warnings.patch

--- a/aports/kde/falkon/APKBUILD
+++ b/aports/kde/falkon/APKBUILD
@@ -1,0 +1,33 @@
+pkgname=falkon
+pkgver=3.0.1
+pkgrel=0
+pkgdesc="A KDE-based web browser using QtWebEngine rendering engine"
+url="https://www.falkon.org/"
+arch="all"
+license="GPL-3.0-or-later"
+depends=""
+makedepends="cmake extra-cmake-modules qt5-qtdeclarative-dev qt5-qtwebengine-dev qt5-qtx11extras-dev qt5-qttools-dev xcb-util-dev ki18n-dev"
+source="https://download.kde.org/stable/falkon/$pkgver/falkon-$pkgver.tar.xz
+	disable-ld-fatal-warnings.patch
+	disable-backtraces.patch
+	"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build () {
+	mkdir -p "$builddir/build"
+	cd "$builddir/build"
+	cmake ..  \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+package() {
+	cd "$builddir/build"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="e2384cb49d4e1ec52ff7804cf798688be2d80fa5957c72accb09376aa0c41ee491c45234fd53c79871bc474a8d0677e40ddb48241a70d77102c67406b0719191  falkon-3.0.1.tar.xz
+fa3df8f056198c6120b4da8fc4b62b08ac9ab5f2c97e76a45eca8db1a41a03b64696681fe35b939cf2f8472f6bb8844d3baac8c5f979d0bf99b9a329259f50e4  disable-ld-fatal-warnings.patch
+0fb09a9219ecbc6ee5c0f7e3721c33b186f6040be254f72f1901cab047d37402edd881ab42448ad4aeda2d1286c963c33a720b2ed47f321c55755ecdf12f0ec4  disable-backtraces.patch"

--- a/aports/kde/falkon/APKBUILD
+++ b/aports/kde/falkon/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=falkon
 pkgver=3.0.1
 pkgrel=0
-pkgdesc="A KDE-based web browser using QtWebEngine rendering engine"
+pkgdesc="Cross-platform web browser using QtWebEngine rendering engine"
 url="https://www.falkon.org/"
 arch="all"
 license="GPL-3.0-or-later"

--- a/aports/kde/falkon/disable-backtraces.patch
+++ b/aports/kde/falkon/disable-backtraces.patch
@@ -1,0 +1,35 @@
+From ae573b560d0e59a2a32e0e6c20a5522e52fb8b2c Mon Sep 17 00:00:00 2001
+From: George Hopkins <george-hopkins@null.net>
+Date: Thu, 31 May 2018 13:00:01 +0200
+Subject: [PATCH] Disable backtraces
+
+Signed-off-by: George Hopkins <george-hopkins@null.net>
+---
+ src/main/main.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/main/main.cpp b/src/main/main.cpp
+index c1af1b6..cdf938d 100644
+--- a/src/main/main.cpp
++++ b/src/main/main.cpp
+@@ -22,7 +22,7 @@
+ #include <QMessageBox> // For QT_REQUIRE_VERSION
+ #include <iostream>
+ 
+-#if defined(Q_OS_LINUX) || defined(__GLIBC__) || defined(__FreeBSD__) || defined(__HAIKU__)
++#if (defined(Q_OS_LINUX) || defined(__GLIBC__) || defined(__FreeBSD__) || defined(__HAIKU__)) && defined(HAVE_BACKTRACE)
+ #include <signal.h>
+ #include <execinfo.h>
+ 
+@@ -129,7 +129,7 @@ int main(int argc, char* argv[])
+     qInstallMessageHandler(&msgHandler);
+ #endif
+ 
+-#if defined(Q_OS_LINUX) || defined(__GLIBC__) || defined(__FreeBSD__)
++#if (defined(Q_OS_LINUX) || defined(__GLIBC__) || defined(__FreeBSD__) || defined(__HAIKU__)) && defined(HAVE_BACKTRACE)
+     signal(SIGSEGV, falkon_signal_handler);
+ #endif
+ 
+-- 
+2.7.4
+

--- a/aports/kde/falkon/disable-ld-fatal-warnings.patch
+++ b/aports/kde/falkon/disable-ld-fatal-warnings.patch
@@ -1,0 +1,29 @@
+From 62ec63fab15b1835c94212f47c04636662e0ac76 Mon Sep 17 00:00:00 2001
+From: George Hopkins <george-hopkins@null.net>
+Date: Thu, 31 May 2018 12:55:06 +0200
+Subject: [PATCH 1/2] Disable fatal linker warnings
+
+libQt5Network.so depends on EVP_CipherFinal which throws a warning.
+
+Signed-off-by: George Hopkins <george-hopkins@null.net>
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cb35545..357fafe 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -143,6 +143,9 @@ if (EXISTS "${CMAKE_SOURCE_DIR}/.git")
+   endif()
+ endif()
+ 
++set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-fatal-warnings")
++set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--no-fatal-warnings")
++
+ configure_file(config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/src/config.h)
+ 
+ # Include dirs used everywhere
+-- 
+2.7.4
+


### PR DESCRIPTION
This pull-request adds a receipt to package [Falkon](https://www.falkon.org/), a cross-plattform browser based on QtWebEngine (previously known as QupZilla). It is targeted towards KDE users but can be used on other platforms, too.

Tested with QEMU (amd64):

![Screenshot](https://user-images.githubusercontent.com/552590/40788974-9de53714-64f1-11e8-8101-b9786ee7c804.png)

---
[x] Merge on GitHub (see <https://postmarketos.org/merge>)
