### PR TITLE
htc-ace: fix WiFi firmware

### DIFF
--- a/aports/device/device-htc-ace/APKBUILD
+++ b/aports/device/device-htc-ace/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=device-htc-ace
 pkgver=1
-pkgrel=10
+pkgrel=11
 pkgdesc="HTC Desire HD"
 url="https://github.com/postmarketOS"
 arch="noarch"
@@ -27,7 +27,7 @@ package() {
 
 nonfree_firmware() {
 	pkgdesc="Wifi firmware"
-	depends="linux-firmware"
+	depends="firmware-aosp-broadcom-wlan"
 	mkdir "$subpkgdir"
 }
 

--- a/aports/device/linux-htc-ace/APKBUILD
+++ b/aports/device/linux-htc-ace/APKBUILD
@@ -20,7 +20,7 @@ case $pkgver in
 	*.*.*)  _kernver=${pkgver%.*};;
 	*.*) _kernver=$pkgver;;
 esac
-pkgrel=7
+pkgrel=8
 arch="armhf"
 pkgdesc="HTC Desire kernel from OpenDesireProject"
 url="https://github.com/OpenDesireProject/android_kernel_htc_msm7x30"
@@ -105,6 +105,6 @@ package() {
 }
 
 sha512sums="72fc35e1c7fe848ae5c1139176d4c45ef042d494403ab38e5fa98e3620fce3253ffc4bf7151738c7dd47967f2ad96b034a9365dc68f1c025aef87e985d5b1776  linux-htc-ace-887cd64b8361ac89ac56810460947a537112bdc9.tar.gz
-e52f2cc5610d286405aa60b6a0a594da0c4fdefa3d4a711da7405f9be573aa9be0d4c373a90e31d7cdb483e66cd232fc6af98c51e3906768a9cdecb69121cdf6  config-htc-ace.armhf
+099f8891a0a7e61f6bfff872b8efaf0af5d8a0f8dcb195b69a7537832ab983636480eed84e1896814a8ddea16ba5de7caef9e7c2dd801731eb7a8dc4af3b96cb  config-htc-ace.armhf
 d80980e9474c82ba0ef1a6903b434d8bd1b092c40367ba543e72d2c119301c8b2d05265740e4104ca1ac5d15f6c4aa49e8776cb44264a9a28dc551e0d1850dcc  compiler-gcc6.h
 2962e853aea3bec3cfea762584a6722023c5c9041994065a7ee75b6c4584121890d6dd1ac74317a2bb8069bff49583a9cccd73cca539665a76713465e05a2cf6  02_gpu-msm-fix-gcc5-compile.patch"

--- a/aports/device/linux-htc-ace/config-htc-ace.armhf
+++ b/aports/device/linux-htc-ace/config-htc-ace.armhf
@@ -1311,7 +1311,7 @@ CONFIG_BCMDHD_GOOGLE=y
 # CONFIG_ATH_COMMON is not set
 # CONFIG_BCM4329 is not set
 CONFIG_BCMDHD=y
-CONFIG_BCMDHD_FW_PATH="/system/vendor/firmware/fw_bcmdhd.bin"
+CONFIG_BCMDHD_FW_PATH="/lib/firmware/postmarketos/bcmdhd/bcm4329/fw_bcm4329.bin"
 CONFIG_BCMDHD_NVRAM_PATH="/proc/calibration"
 CONFIG_DHD_USE_STATIC_BUF=y
 # CONFIG_DHD_USE_SCHED_SCAN is not set


### PR DESCRIPTION
This patch pulls the correct firmware and fixes the path to it. The firmware is the same as the one used by the OpenDesireProject (whose kernel source we already use).

---
[x] Merge on GitHub (see <https://postmarketos.org/merge>)
