### PR TITLE
device-samsung-p4wifi: Change touchscreen to /dev/input/event1

### DIFF
--- a/aports/device/device-samsung-p4wifi/APKBUILD
+++ b/aports/device/device-samsung-p4wifi/APKBUILD
@@ -2,7 +2,7 @@
 pkgname="device-samsung-p4wifi"
 pkgdesc="Galaxy Tab 10.1"
 pkgver=0.1
-pkgrel=5
+pkgrel=6
 url="https://postmarketos.org"
 license="MIT"
 arch="noarch"
@@ -46,7 +46,7 @@ nonfree_firmware() {
 	mkdir "$subpkgdir"
 }
 
-sha512sums="0622c4326811e2240d1278b991476bffb3e53831ffc81e9d45c8ad73fd8a1a2aaafabaaad9aa9c4440834d3626fade2d674a59773a215c52319cd79c09f4a6c0  deviceinfo
+sha512sums="2bcd18ab55da72365043fcb8944d3e354038d596af25c80e4ea4b0e2681f01aa90d1142aefbf1b4f67da569fe26d75d059c6c2cff6ce5f6c33cd6d14b56f1b2d  deviceinfo
 d8ce60ea7acaabf627ddca2f0887a4cda46f313b7aaf7934bef2fef8a6e0798ccefab849e4571e4e3fcd06ae34c1a6efe3b58b401e2e443416f6200e6d4ea769  modules-load.conf
 56b865bab0714aed53bd6535ebefd2f3629ec78786e8f87dcae4637cfacb5912d28dc39d1fe0287d34bb36b4a8371481f54647e1b25190afbcd23ed30fe7edac  modprobe.conf
 559d3f49a2a99445c644f53b1148fbac6963cc27fc77ba735da7b6c742b8d4faecf938943ce598ea71d590ce2297e2ec6f98aec54b2b339c861f92d0e0430434  90-device-samsung-p4wifi-audio.rules

--- a/aports/device/device-samsung-p4wifi/deviceinfo
+++ b/aports/device/device-samsung-p4wifi/deviceinfo
@@ -14,7 +14,7 @@ deviceinfo_keyboard="false"
 deviceinfo_external_storage="false"
 deviceinfo_screen_width="1280"
 deviceinfo_screen_height="720"
-deviceinfo_dev_touchscreen="/dev/input/event5"
+deviceinfo_dev_touchscreen="/dev/input/event1"
 deviceinfo_dev_touchscreen_calibration=""
 deviceinfo_dev_keyboard=""
 


### PR DESCRIPTION
The headphone jack (sec_jack) driver no longer registers as an input device
itself. It now listens for events on the gpio-keys input device. This
changed the enumeration of /dev/input devices. The touchscreen is now
/dev/input/event1.

This fixes things which depend on deviceinfo_dev_touchscreen such as
osk-sdl.
