### PR TITLE
Feature/devicepkg dev kernel functions

### DIFF
--- a/aports/device/linux-amazon-thor/APKBUILD
+++ b/aports/device/linux-amazon-thor/APKBUILD
@@ -10,7 +10,7 @@ _flavor="amazon-thor"
 url="https://kernel.org"
 license="GPL2"
 options="!strip !check !tracedeps"
-makedepends="perl sed installkernel bash gmp-dev bc linux-headers elfutils-dev xz dtbtool"
+makedepends="perl sed installkernel bash gmp-dev bc linux-headers elfutils-dev xz dtbtool devicepkg-dev"
 HOSTCC="${CC:-gcc}"
 HOSTCC="${HOSTCC#${CROSS_COMPILE}}"
 
@@ -34,23 +34,8 @@ source="
 builddir="$srcdir/${_repository}-${_commit}"
 
 prepare() {
-	default_prepare
-
-	# gcc6 support
-	cp -v "$srcdir/compiler-gcc6.h" "$builddir/include/linux/"
-
-	# Remove -Werror from all makefiles
-	local i
-	local makefiles="$(find . -type f -name Makefile)
-		$(find . -type f -name Kbuild)"
-	for i in $makefiles; do
-		sed -i 's/-Werror-/-W/g' "$i"
-		sed -i 's/-Werror//g' "$i"
-	done
-
-	# Prepare kernel config ('yes ""' for kernels lacking olddefconfig)
-	cp "$srcdir"/$_config "$builddir"/.config
-	yes "" | make ARCH="$_carch" HOSTCC="$HOSTCC" oldconfig
+	. /usr/share/pmbootstrap/kernelpkg_functions.sh
+	downstreamkernel_prepare
 }
 
 build() {
@@ -85,7 +70,7 @@ package() {
 }
 
 sha512sums="7d9f9001c6fc11954922070e3ed18f7e2843d5cd45dbab0f86ab332d6c45ee0279dd2c9bf498d91c017322f8b56f7f7417f132201bf2104ea5826212d09224f7  linux-amazon-thor-f73e4eec8717c6104eca954cf9c259d9d37c38a5.tar.gz
-d682b04c30b7829d6e90b4ad3eb40201ff253dfdb1717742b6b6574b8d3c86abc95e6f7ee8e8ab097520b41e0240b06bdd75fc8be727ac481e656c4d23f8dd30  config-amazon-thor.armhf
+903a8bac7a63278d56a9bea412b700b6d833cddc19065f2a53afbaee1fccce66b6df170413bd4667620f2739662b2032ed8d0cc926856229595afd41a27e8f1c  config-amazon-thor.armhf
 d80980e9474c82ba0ef1a6903b434d8bd1b092c40367ba543e72d2c119301c8b2d05265740e4104ca1ac5d15f6c4aa49e8776cb44264a9a28dc551e0d1850dcc  compiler-gcc6.h
 ddf6caae3f087f21fbfdc258da1c05731bc14c24fe25ce1383133140129d44c48dc427b52d93ed7395def9ad5bf4dab01cc2792581c8ec3e10278c014a64d240  00_fix_smd_private.patch
 f40a9b3395882046adc66f97631dc85815f1901471559a40df502ec3fb0334ce2fd14202cd2a2b0de5a5e78deb103983bb0bcf9a5dce14cf1048b9750ebba6fa  00_fix_qaudio.patch

--- a/aports/device/linux-asus-grouper/APKBUILD
+++ b/aports/device/linux-asus-grouper/APKBUILD
@@ -1,99 +1,62 @@
-# APKBUILD based on linux-vanilla aport. Changes:
-# - disabled module installation
-# - add !check !tracedeps
-# - package: just install zimage and kernel.release, because the kernel config
-#	does not generate modules or dtb files
-# - do not create -dev subpackage (makes no sense without module support)
-#
 # Kernel config based on: arch/arm/configs/lineageos_grouper_defconfig
-# Changes:
-# - enable devtmpfs (needed for udev -> touch support in weston)
-# - disable ANDROID_PARANOID_NETWORK (removes network restrictions)
-
-_vendor=asus
-_flavor=asus-grouper
-_hash="953e26f2709dfe0c185c3c99c50b0c9d56d473a4"
-_config="config-${_flavor}.armhf"
-
-pkgname=linux-${_flavor}
+pkgname="linux-asus-grouper"
 pkgver=3.4.0
-case $pkgver in
-	*.*.*)  _kernver=${pkgver%.*};;
-	*.*) _kernver=$pkgver;;
-esac
 pkgrel=8
-arch="armhf"
 pkgdesc="Nexus 7 (2012) kernel from LineageOS"
+arch="armhf"
+_carch="arm"
+_flavor="asus-grouper"
 url="https://github.com/LineageOS/android_kernel_asus_grouper"
-depends=""
-makedepends="perl sed installkernel bash gmp-dev bc linux-headers elfutils-dev"
+license="GPL2"
 options="!strip !check !tracedeps"
-install=
+makedepends="perl sed installkernel bash gmp-dev bc linux-headers elfutils-dev devicepkg-dev"
+HOSTCC="${CC:-gcc}"
+HOSTCC="${HOSTCC#${CROSS_COMPILE}}"
+
+# Source
+_repository="android_kernel_asus_grouper"
+_commit="953e26f2709dfe0c185c3c99c50b0c9d56d473a4"
+_config="config-${_flavor}.${arch}"
 source="
-	$pkgname-$_hash.tar.gz::https://github.com/LineageOS/android_kernel_asus_grouper/archive/${_hash}.tar.gz
+	$pkgname-$_commit.tar.gz::https://github.com/LineageOS/${_repository}/archive/${_commit}.tar.gz
 	$_config
 	compiler-gcc6.h
 	duplicate-return-address-definition.patch
 "
-subpackages=""
-license="GPL2"
-
-_abi_release=${pkgver}
-_carch="arm"
-HOSTCC="${CC:-gcc}"
-HOSTCC="${HOSTCC#${CROSS_COMPILE}}"
-
-#ksrcdir="$srcdir/${_vendor}-kernel-grouper-${_hash}"
-ksrcdir="$srcdir/android_kernel_asus_grouper-${_hash}"
+builddir="$srcdir/${_repository}-${_commit}"
 
 prepare() {
-	local _patch_failed=
-	cd "$ksrcdir"
-
-	# first apply patches in specified order
-	for i in $source; do
-		case $i in
-		*.patch)
-			msg "Applying $i..."
-			if ! patch -s -p1 -N -i "$srcdir"/$i; then
-				echo $i >>failed
-				_patch_failed=1
-			fi
-			;;
-		esac
-	done
-
-	if ! [ -z "$_patch_failed" ]; then
-		error "The following patches failed:"
-		cat failed
-		return 1
-	fi
-
-	# gcc6 support
-	cp -v "$srcdir/compiler-gcc6.h" "$ksrcdir/include/linux/"
-
-	mkdir -p "$srcdir"/build
-	cp "$srcdir"/$_config "$srcdir"/build/.config
-	make -C "$ksrcdir" O="$srcdir"/build ARCH="$_carch" HOSTCC="$HOSTCC" \
-		silentoldconfig
+	. /usr/share/pmbootstrap/kernelpkg_functions.sh
+	downstreamkernel_prepare
 }
 
 build() {
-	cd "$srcdir"/build
 	unset LDFLAGS
 	make ARCH="$_carch" CC="${CC:-gcc}" \
-		KBUILD_BUILD_VERSION="$((pkgrel + 1 ))-Alpine"
+		KBUILD_BUILD_VERSION="$((pkgrel + 1 ))-postmarketOS"
 }
 
 package() {
-	install -Dm644 "$srcdir/build/arch/arm/boot/zImage" \
-		"$pkgdir/boot/vmlinuz-$_flavor"
-
-	install -D "$srcdir/build/include/config/kernel.release" \
+	# kernel.release
+	install -D "$builddir/include/config/kernel.release" \
 		"$pkgdir/usr/share/kernel/$_flavor/kernel.release"
+
+	# zImage (find the right one)
+	cd "$builddir/arch/$_carch/boot"
+	_target="$pkgdir/boot/vmlinuz-$_flavor"
+	for _zimg in zImage-dtb Image.gz-dtb *zImage Image; do
+		[ -e "$_zimg" ] || continue
+		msg "zImage found: $_zimg"
+		install -Dm644 "$_zimg" "$_target"
+		break
+	done
+	if ! [ -e "$_target" ]; then
+		error "Could not find zImage in $PWD!"
+		return 1
+	fi
 }
 
 sha512sums="11ba20986552a0b913de2a7d756d31ad9f4f67561cb88988737bba07997f00b7574604d1c19f6d890502208f12a21d48d4044edc5a8db5174b2a49d4a87573e3  linux-asus-grouper-953e26f2709dfe0c185c3c99c50b0c9d56d473a4.tar.gz
-a9614499186eb0f7a7b37d07a99b1a8fa5b093370bed2c0d4f7b978b49a47ac858c6cabfa4ec97ca6fec1f579bd342c38722ef930de120ecda78be0341e41411  config-asus-grouper.armhf
+f06f3f69abc6af37786ab11b197cd640ac107e570e44fea57b2a912029329e497ca0a3e2569bdba0f3586215c2b5521ed21d03b8f6588c5414fb4fe5cdfee747  config-asus-grouper.armhf
 d80980e9474c82ba0ef1a6903b434d8bd1b092c40367ba543e72d2c119301c8b2d05265740e4104ca1ac5d15f6c4aa49e8776cb44264a9a28dc551e0d1850dcc  compiler-gcc6.h
 9b15bf1f6cb66f54c785b0af6c9db8a7d63257e6fa3eeb0cbf47284334166aa6a7ff93e1b64ab69206c8047d64641199c0f5fcbc257bbe039263252fff45118e  duplicate-return-address-definition.patch"

--- a/aports/main/devicepkg-dev/APKBUILD
+++ b/aports/main/devicepkg-dev/APKBUILD
@@ -1,5 +1,5 @@
 pkgname="devicepkg-dev"
-pkgver=0.2
+pkgver=0.3
 pkgrel=0
 pkgdesc="Provides default device package functions"
 url="https://github.com/postmarketOS"
@@ -8,6 +8,7 @@ license="MIT"
 source="
 	devicepkg_build.sh
 	devicepkg_package.sh
+	kernelpkg_functions.sh
 "
 
 package() {
@@ -15,6 +16,9 @@ package() {
 		"$pkgdir/usr/bin/devicepkg_build"
 	install -Dm755 "$srcdir/devicepkg_package.sh" \
 		"$pkgdir/usr/bin/devicepkg_package"
+	install -Dm755 "$srcdir/kernelpkg_functions.sh" \
+		"$pkgdir/usr/share/pmbootstrap/kernelpkg_functions.sh"
 }
 sha512sums="638d50e6388eabf0da6bf0cff2fe9719ad8a808946f0077228db57fa13a26d9eeb39c1f2689c9a6f93ff9b3bcfdcfb7c358b180bba90e5bba8b9a9e78d25ed18  devicepkg_build.sh
-c732792596f56860f6ab9ddd53b9a7a80224400dd20097b20cebe17a6e7330e9178783f09db16132a28a555f83e29ef3643bfe069638b62998912a9a7ffefdc0  devicepkg_package.sh"
+c732792596f56860f6ab9ddd53b9a7a80224400dd20097b20cebe17a6e7330e9178783f09db16132a28a555f83e29ef3643bfe069638b62998912a9a7ffefdc0  devicepkg_package.sh
+f72f9f7ed1110f3cd343f8df6ebdf6d893ffbf38a45298da7a080bf1c83665b9b191b2f6c93dbaad891579c7b66cdc946a83f9bc097d3b6d7d219c7994a0ec8c  kernelpkg_functions.sh"

--- a/aports/main/devicepkg-dev/kernelpkg_functions.sh
+++ b/aports/main/devicepkg-dev/kernelpkg_functions.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+downstreamkernel_prepare() {
+	default_prepare
+
+	# gcc6 support
+	# shellcheck disable=SC2154
+	cp -v "$srcdir/compiler-gcc6.h" "$builddir/include/linux/"
+
+	# Remove -Werror from all makefiles
+	makefiles="$(find . -type f -name Makefile)
+		$(find . -type f -name Kbuild)"
+	for i in $makefiles; do
+		sed -i 's/-Werror-/-W/g' "$i"
+		sed -i 's/-Werror//g' "$i"
+	done
+
+	# Prepare kernel config ('yes ""' for kernels lacking olddefconfig)
+	# shellcheck disable=SC2154
+	cp "$srcdir/$_config" "$builddir"/.config
+	# shellcheck disable=SC2154
+	yes "" | make ARCH="$_carch" HOSTCC="$HOSTCC" oldconfig
+}

--- a/pmb/aportgen/linux.py
+++ b/pmb/aportgen/linux.py
@@ -26,7 +26,7 @@ def generate_apkbuild(args, pkgname, deviceinfo):
     device = "-".join(pkgname.split("-")[1:])
     carch = pmb.parse.arch.alpine_to_kernel(deviceinfo["arch"])
 
-    makedepends = "perl sed installkernel bash gmp-dev bc linux-headers elfutils-dev"
+    makedepends = "perl sed installkernel bash gmp-dev bc linux-headers elfutils-dev devicepkg-dev"
 
     package = """
             # kernel.release
@@ -95,24 +95,8 @@ def generate_apkbuild(args, pkgname, deviceinfo):
         builddir="$srcdir/${_repository}-${_commit}"
 
         prepare() {
-            default_prepare
-
-            # gcc6 support
-            cp -v "$srcdir/compiler-gcc6.h" "$builddir/include/linux/"
-
-            # Remove -Werror from all makefiles
-            local i
-            local makefiles="$(find . -type f -name Makefile)
-                $(find . -type f -name Kbuild)"
-            for i in $makefiles; do
-                sed -i 's/-Werror-/-W/g' "$i"
-                sed -i 's/-Werror//g' "$i"
-            done
-
-            # Prepare kernel config ('yes ""' for kernels lacking olddefconfig)
-            mkdir -p "$srcdir"/build
-            cp "$srcdir"/$_config "$builddir"/.config
-            yes "" | make O="$srcdir"/build ARCH="$_carch" HOSTCC="$HOSTCC" oldconfig
+            . /usr/share/pmbootstrap/kernelpkg_functions.sh
+            downstreamkernel_prepare
         }
 
         build() {""" + build + """

--- a/pmb/build/menuconfig.py
+++ b/pmb/build/menuconfig.py
@@ -102,14 +102,16 @@ def menuconfig(args, pkgname):
     # Run make menuconfig
     srcdir = "/home/pmos/build/src"
     logging.info("(native) make " + kopt)
+    builddir = pmb.chroot.user(args, ["sh", "-c", "source APKBUILD; echo $builddir"],
+                               "native", "/home/pmos/build", return_stdout=True).rstrip()
     pmb.chroot.user(args, ["make", kopt], "native",
-                    srcdir + "/build", log=False,
+                    srcdir + builddir, log=False,
                     env={"ARCH": pmb.parse.arch.alpine_to_kernel(arch),
                          "DISPLAY": os.environ.get("DISPLAY"),
                          "XAUTHORITY": "/home/pmos/.Xauthority"})
 
     # Find the updated config
-    source = args.work + "/chroot_native" + srcdir + "/build/.config"
+    source = args.work + "/chroot_native" + srcdir + builddir + "/.config"
     if not os.path.exists(source):
         raise RuntimeError("No kernel config generated: " + source)
 


### PR DESCRIPTION
Changes:

- Update the `devicepkg-dev` with a new `kernelpkg_functions.sh` script which contains the `downstreamkernel_prepare` function discussed in https://github.com/postmarketOS/pmbootstrap/issues/688#issuecomment-384747760

- Revert the changes in #1556 and use the `downstreamkernel_prepare` in the `prepare` function

- Fix `pmbootstrap kconfig edit` by reading the value of the `builddir` and executing `make menuconfig` directly inside the builddir

- Update some old APKBUILD kernel packages (to be continued)

Close: #1551

---
[x] Merge on GitHub (see <https://postmarketos.org/merge>)
