### PR TITLE
kde/kwin: workaround the regression introduced in upstream (#1579)

### DIFF
--- a/aports/kde/kwin/0001-Revert-udev-Only-handle-devices-from-the-current-sea.patch
+++ b/aports/kde/kwin/0001-Revert-udev-Only-handle-devices-from-the-current-sea.patch
@@ -1,0 +1,55 @@
+From bf01478615db30fe1357b2e54ec6b345d6acd196 Mon Sep 17 00:00:00 2001
+From: Bhushan Shah <bhush94@gmail.com>
+Date: Tue, 19 Jun 2018 08:26:46 +0530
+Subject: [PATCH] Revert "udev: Only handle devices from the current seat"
+
+This reverts commit 99376d38f69f6bcc13d7a8ebdb679b7c18e30586.
+---
+ udev.cpp | 10 +---------
+ 1 file changed, 1 insertion(+), 9 deletions(-)
+
+diff --git a/udev.cpp b/udev.cpp
+index f064b089b..e3b2406c3 100644
+--- a/udev.cpp
++++ b/udev.cpp
+@@ -18,7 +18,6 @@ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *********************************************************************/
+ #include "udev.h"
+-#include "logind.h"
+ // Qt
+ #include <QByteArray>
+ #include <QScopedPointer>
+@@ -107,7 +106,6 @@ UdevDevice::Ptr UdevEnumerate::find(std::function<bool(const UdevDevice::Ptr &de
+     if (m_enumerate.isNull()) {
+         return UdevDevice::Ptr();
+     }
+-    QString defaultSeat = QStringLiteral("seat0");
+     udev_list_entry *it = udev_enumerate_get_list_entry(m_enumerate.data());
+     UdevDevice::Ptr firstFound;
+     while (it) {
+@@ -117,13 +115,6 @@ UdevDevice::Ptr UdevEnumerate::find(std::function<bool(const UdevDevice::Ptr &de
+         if (!device) {
+             continue;
+         }
+-        QString deviceSeat = device->property("ID_SEAT");
+-        if (deviceSeat.isEmpty()) {
+-            deviceSeat = defaultSeat;
+-        }
+-        if (deviceSeat != LogindIntegration::self()->seat()) {
+-            continue;
+-        }
+         if (test(device)) {
+             return device;
+         }
+@@ -144,6 +135,7 @@ UdevDevice::Ptr Udev::primaryGpu()
+     enumerate.addMatch(UdevEnumerate::Match::SysName, "card[0-9]*");
+     enumerate.scan();
+     return enumerate.find([](const UdevDevice::Ptr &device) {
++        // TODO: check seat
+         auto pci = device->getParentWithSubsystemDevType("pci");
+         if (!pci) {
+             return false;
+-- 
+2.17.1
+

--- a/aports/kde/kwin/APKBUILD
+++ b/aports/kde/kwin/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kwin
 pkgver=5.13.0
-pkgrel=0
+pkgrel=1
 pkgdesc='An easy to use, but flexible, composited Window Manager'
 arch="all"
 url='https://www.kde.org/workspaces/plasmadesktop/'
@@ -18,7 +18,8 @@ depends_dev="kdecoration-dev kjobwidgets-dev kcmutils-dev kscreenlocker-dev bree
 			kdeclarative-dev kactivities-dev qt5-qtsensors-dev"
 makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev kdoctools-dev libxkbcommon-dev
 			libepoxy-dev libinput-dev xcb-util-cursor-dev libdrm-dev eudev-dev xcb-util-wm-dev"
-source="https://download.kde.org/stable/plasma/${pkgver}/${pkgname}-${pkgver}.tar.xz"
+source="https://download.kde.org/stable/plasma/${pkgver}/${pkgname}-${pkgver}.tar.xz
+		0001-Revert-udev-Only-handle-devices-from-the-current-sea.patch"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 options="!check" # Fails due to requiring running X11
 
@@ -41,4 +42,5 @@ package() {
 	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 }
-sha512sums="0ccd927e0745a0afc831f59882f3e33169b276ed79c7e42721842ab2fbf2f8b17ac451943d140ce98ee89478b476f900f9004a3f513fe4d8753666be4a4375e2  kwin-5.13.0.tar.xz"
+sha512sums="0ccd927e0745a0afc831f59882f3e33169b276ed79c7e42721842ab2fbf2f8b17ac451943d140ce98ee89478b476f900f9004a3f513fe4d8753666be4a4375e2  kwin-5.13.0.tar.xz
+a34ff6926f020117fafd8a31c18a183eecb3e0a5fe6c3f2784f531171552350615fb06cbac2f3a1248011eb83ec32fc9df4b64f82443dee1d8e90c1be49e2690  0001-Revert-udev-Only-handle-devices-from-the-current-sea.patch"


### PR DESCRIPTION
I have better fix planned but unfortunately I won't get it to work
before Plasma 5.13.2 release (Plasma 5.13.1 is due today).

Fixes #1574

---
[x] Merge on GitHub (see <https://postmarketos.org/merge>)
