### PR TITLE
Use Alpine's qemu "pmbootstrap qemu"

### DIFF
--- a/aports/main/qemu/0001-elfload-load-PIE-executables-to-right-address.patch
+++ b/aports/main/qemu/0001-elfload-load-PIE-executables-to-right-address.patch
@@ -1,0 +1,89 @@
+From 6818f32f74981d9bccec8afbab37c42b50ab58be Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Timo=20Ter=C3=A4s?= <timo.teras@iki.fi>
+Date: Thu, 4 Jul 2013 15:50:36 +0300
+Subject: [RFC PATCH] elfload: load PIE executables to right address
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+PIE images are ET_DYN images. Check first for pinterp_name to make
+sure the main executable always is loaded to correct place.
+
+See below for current behaviour of PIE executables:
+
+Reserved 0x7f000000 bytes of guest address space
+host mmap_min_addr=0x1000
+guest_base  0x7f7cb41d5000
+start    end      size     prot
+0037f400-003fe400 0007f000 r-x
+003fe400-003ff400 00001000 ---
+003ff400-003fe400 fffff000 rw-
+003fe400-003ff400 00001000 ---
+003ff400-003ffc00 00000800 rw-
+003ffc00-003fec00 fffff000 r-x
+003fec00-003ffc00 00001000 ---
+003ffc00-0007f000 ffc7f400 rw-
+start_brk   0x00000000
+end_code    0x7eff7ac0
+start_code  0x7eff7000
+start_data  0x7efffac0
+end_data    0x7efffc18
+start_stack 0x7eff6dc8
+brk         0x7efffc34
+entry       0x7e799b30
+00000000-00005000 ---p 00000000 00:00 0
+00005000-00015000 rw-p 00000000 00:00 0
+00015000-7e77d000 ---p 00000000 00:00 0
+7e77d000-7e7ec000 r-xp 00000000 68:03 14326298          /lib/libc.so
+7e7ec000-7e7f3000 ---p 00000000 00:00 0
+7e7f3000-7e7f4000 rw-p 0006e000 68:03 14326298          /lib/libc.so
+7e7f4000-7e7f6000 rw-p 00000000 00:00 0
+7e7f6000-7e7f7000 ---p 00000000 00:00 0
+7e7f7000-7eff7000 rw-p 00000000 00:00 0
+7eff7000-7eff8000 r-xp 00000000 68:03 9731305          /usr/bin/brk
+7eff8000-7efff000 ---p 00000000 00:00 0
+7e7f7000-7eff7000 rw-p 00000000 00:00 0          [stack]
+
+Showing how the main binary got loaded to wrong place.
+
+Signed-off-by: Timo Teräs <timo.teras@iki.fi>
+---
+I assume pinterp_name is only ever set for the main executable.
+Quick grep would indicate that this is indeed the case.
+
+ linux-user/elfload.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/linux-user/elfload.c b/linux-user/elfload.c
+index ddef23e..d6e00cd 100644
+--- a/linux-user/elfload.c
++++ b/linux-user/elfload.c
+@@ -1660,7 +1660,12 @@ static void load_elf_image(const char *image_name, int image_fd,
+     }
+ 
+     load_addr = loaddr;
+-    if (ehdr->e_type == ET_DYN) {
++    if (pinterp_name != NULL) {
++        /* This is the main executable.  Make sure that the low
++           address does not conflict with MMAP_MIN_ADDR or the
++           QEMU application itself.  */
++        probe_guest_base(image_name, loaddr, hiaddr);
++    } else if (ehdr->e_type == ET_DYN) {
+         /* The image indicates that it can be loaded anywhere.  Find a
+            location that can hold the memory space required.  If the
+            image is pre-linked, LOADDR will be non-zero.  Since we do
+@@ -1672,11 +1677,6 @@ static void load_elf_image(const char *image_name, int image_fd,
+         if (load_addr == -1) {
+             goto exit_perror;
+         }
+-    } else if (pinterp_name != NULL) {
+-        /* This is the main executable.  Make sure that the low
+-           address does not conflict with MMAP_MIN_ADDR or the
+-           QEMU application itself.  */
+-        probe_guest_base(image_name, loaddr, hiaddr);
+     }
+     load_bias = load_addr - loaddr;
+ 
+-- 
+1.8.3.2
+

--- a/aports/main/qemu/0001-linux-user-fix-build-with-musl-on-aarch64.patch
+++ b/aports/main/qemu/0001-linux-user-fix-build-with-musl-on-aarch64.patch
@@ -1,0 +1,31 @@
+From 806cb2ed28a16cf2894fabef034347f426f1d04e Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Thu, 15 Dec 2016 11:53:07 +0100
+Subject: [PATCH] linux-user: fix build with musl on aarch64
+
+Use the standard uint64_t instead of internal __u64.
+
+This fixes compiler error with musl libc on aarch64:
+.../qemu-2.7.0/linux-user/host/aarch64/hostdep.h:28:5:
+error: unknown type name '__u64'
+     __u64 *pcreg = &uc->uc_mcontext.pc;
+     ^~~~~
+
+Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>
+---
+ linux-user/host/aarch64/hostdep.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/linux-user/host/aarch64/hostdep.h b/linux-user/host/aarch64/hostdep.h
+index 64f75cef49..6fd6e36b2a 100644
+--- a/linux-user/host/aarch64/hostdep.h
++++ b/linux-user/host/aarch64/hostdep.h
+@@ -25,7 +25,7 @@ extern char safe_syscall_end[];
+ static inline void rewind_if_in_safe_syscall(void *puc)
+ {
+     ucontext_t *uc = puc;
+-    __u64 *pcreg = &uc->uc_mcontext.pc;
++    uint64_t *pcreg = &uc->uc_mcontext.pc;
+ 
+     if (*pcreg > (uintptr_t)safe_syscall_start
+         && *pcreg < (uintptr_t)safe_syscall_end) {

--- a/aports/main/qemu/0001-linux-user-fix-build-with-musl-on-ppc64le.patch
+++ b/aports/main/qemu/0001-linux-user-fix-build-with-musl-on-ppc64le.patch
@@ -1,0 +1,67 @@
+--- a/linux-user/host/ppc64/hostdep.h
++++ b/linux-user/host/ppc64/hostdep.h
+@@ -25,7 +25,11 @@
+ static inline void rewind_if_in_safe_syscall(void *puc)
+ {
+     ucontext_t *uc = puc;
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+     unsigned long *pcreg = &uc->uc_mcontext.gp_regs[PT_NIP];
++#else // Musl
++    unsigned long *pcreg = &uc->uc_mcontext.gp_regs[32];
++#endif
+ 
+     if (*pcreg > (uintptr_t)safe_syscall_start
+         && *pcreg < (uintptr_t)safe_syscall_end) {
+--- a/accel/tcg/user-exec.c
++++ a/accel/tcg/user-exec.c
+@@ -228,6 +228,7 @@
+  */
+ #ifdef linux
+ /* All Registers access - only for local access */
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+ #define REG_sig(reg_name, context)              \
+     ((context)->uc_mcontext.regs->reg_name)
+ /* Gpr Registers access  */
+@@ -245,15 +246,42 @@
+ /* Condition register */
+ #define CR_sig(context)                        REG_sig(ccr, context)
+
++#else // Musl
++#define REG_sig(reg_num, context)              \
++    ((context)->uc_mcontext.gp_regs[reg_num])
++/* Gpr Registers access  */
++#define GPR_sig(reg_num, context)              REG_sig(gpr[reg_num], context)
++/* Program counter */
++#define IAR_sig(context)                       REG_sig(32, context)
++/* Machine State Register (Supervisor) */
++#define MSR_sig(context)                       REG_sig(33, context)
++/* Count register */
++#define CTR_sig(context)                       REG_sig(35, context)
++/* User's integer exception register */
++#define XER_sig(context)                       REG_sig(37, context)
++/* Link register */
++#define LR_sig(context)                        REG_sig(36, context)
++/* Condition register */
++#define CR_sig(context)                        REG_sig(38, context)
++#endif
++
++
+ /* Float Registers access  */
+ #define FLOAT_sig(reg_num, context)                                     \
+     (((double *)((char *)((context)->uc_mcontext.regs + 48 * 4)))[reg_num])
+ #define FPSCR_sig(context) \
+     (*(int *)((char *)((context)->uc_mcontext.regs + (48 + 32 * 2) * 4)))
+ /* Exception Registers access */
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+ #define DAR_sig(context)                       REG_sig(dar, context)
+ #define DSISR_sig(context)                     REG_sig(dsisr, context)
+ #define TRAP_sig(context)                      REG_sig(trap, context)
++#else // Musl
++#define DAR_sig(context)                       REG_sig(41, context)
++#define DSISR_sig(context)                     REG_sig(42, context)
++#define TRAP_sig(context)                      REG_sig(40, context)
++#endif
++
+ #endif /* linux */
+
+ #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)

--- a/aports/main/qemu/0001-module-Use-QEMU_MODULE_PATH-as-a-search-path.patch
+++ b/aports/main/qemu/0001-module-Use-QEMU_MODULE_PATH-as-a-search-path.patch
@@ -1,0 +1,85 @@
+From 5bf8d0efa7e02f26dfa08ac68b2d62021bfc3fda Mon Sep 17 00:00:00 2001
+From: ryang <decatf@gmail.com>
+Date: Thu, 28 Jun 2018 13:22:50 -0400
+Subject: [PATCH] module: Use QEMU_MODULE_PATH as a search path
+
+The current paths for modules are CONFIG_QEMU_MODDIR and paths relative
+to the executable. Qemu and its modules can be installed / executed in
+paths that are different from the current search paths. This change allows
+a search path to be specified by environment variable.
+
+An example usage for this is postmarketOS. This is a build environment for
+Alpine Linux. It sets up an Alpine Linux chroot environment. Alpine's Qemu
+packages are installed in the chroot. The Alpine Linux Qemu package is used
+to test compiled Alpine Linux system images. This way there isn't a
+reliance on the which ever version of Qemu the host system / distro
+might provide.
+
+postmarketOS executes Qemu on host system outside of the chroot
+The Qemu module search path needs to point to the location of the
+chroot relative to the host system.
+
+e.g.
+The root of the Alpine Linux chroot is:
+~/.local/var/pmbootstrap/chroot_native/
+The Qemu module search path needs to be:
+QEMU_MODULE_PATH=~/.local/var/pmbootstrap/chroot_native/usr/lib/qemu/
+
+Signed-off-by: ryang <decatf@gmail.com>
+---
+ util/module.c | 21 +++++++++++++--------
+ 1 file changed, 13 insertions(+), 8 deletions(-)
+
+diff --git a/util/module.c b/util/module.c
+index c909737..f9088a5 100644
+--- a/util/module.c
++++ b/util/module.c
+@@ -162,9 +162,10 @@ void module_load_one(const char *prefix, const char *lib_name)
+ #ifdef CONFIG_MODULES
+     char *fname = NULL;
+     char *exec_dir;
+-    char *dirs[3];
++    char *search_path;
++    char *dirs[4];
+     char *module_name;
+-    int i = 0;
++    int i = 0, n_dirs;
+     int ret;
+     static GHashTable *loaded_modules;
+ 
+@@ -186,14 +187,18 @@ void module_load_one(const char *prefix, const char *lib_name)
+     g_hash_table_insert(loaded_modules, module_name, module_name);
+ 
+     exec_dir = qemu_get_exec_dir();
+-    dirs[i++] = g_strdup_printf("%s", CONFIG_QEMU_MODDIR);
+-    dirs[i++] = g_strdup_printf("%s/..", exec_dir ? : "");
+-    dirs[i++] = g_strdup_printf("%s", exec_dir ? : "");
+-    assert(i == ARRAY_SIZE(dirs));
++    search_path = getenv("QEMU_MODULE_PATH");
++    if (search_path != NULL)
++        dirs[n_dirs++] = g_strdup_printf("%s", search_path);
++    dirs[n_dirs++] = g_strdup_printf("%s", CONFIG_QEMU_MODDIR);
++    dirs[n_dirs++] = g_strdup_printf("%s/..", exec_dir ? : "");
++    dirs[n_dirs++] = g_strdup_printf("%s", exec_dir ? : "");
++    assert(n_dirs <= ARRAY_SIZE(dirs));
++
+     g_free(exec_dir);
+     exec_dir = NULL;
+ 
+-    for (i = 0; i < ARRAY_SIZE(dirs); i++) {
++    for (i = 0; i < n_dirs; i++) {
+         fname = g_strdup_printf("%s/%s%s",
+                 dirs[i], module_name, HOST_DSOSUF);
+         ret = module_load_file(fname);
+@@ -205,7 +210,7 @@ void module_load_one(const char *prefix, const char *lib_name)
+         }
+     }
+ 
+-    for (i = 0; i < ARRAY_SIZE(dirs); i++) {
++    for (i = 0; i < n_dirs; i++) {
+         g_free(dirs[i]);
+     }
+ 
+-- 
+2.7.4
+

--- a/aports/main/qemu/0001-ui-add-x_keymap.o-to-modules.patch
+++ b/aports/main/qemu/0001-ui-add-x_keymap.o-to-modules.patch
@@ -1,0 +1,65 @@
+From 68898bc82bcb0e697ed03c2405321033ba7feaf7 Mon Sep 17 00:00:00 2001
+From: Paolo Bonzini <pbonzini@redhat.com>
+Date: Thu, 17 May 2018 14:39:42 +0200
+Subject: [PATCH] ui: add x_keymap.o to modules
+
+x_keymap.o is common to the SDL and GTK+ modules, and it causes the
+QEMU binary to link to the X11 libraries.  Add it separately to the
+modules to keep the main QEMU binary smaller.
+
+Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>
+Message-id: 1526560782-18732-1-git-send-email-pbonzini@redhat.com
+
+[ kraxel: fix lm32 target build (milkymist-tmu2) ]
+
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+---
+ hw/display/Makefile.objs |  2 ++
+ ui/Makefile.objs         | 11 +++++++----
+ 2 files changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/hw/display/Makefile.objs b/hw/display/Makefile.objs
+index 3c7c75b94d..11321e466b 100644
+--- a/hw/display/Makefile.objs
++++ b/hw/display/Makefile.objs
+@@ -20,6 +20,8 @@ common-obj-$(CONFIG_MILKYMIST) += milkymist-vgafb.o
+ common-obj-$(CONFIG_ZAURUS) += tc6393xb.o
+ 
+ common-obj-$(CONFIG_MILKYMIST_TMU2) += milkymist-tmu2.o
++milkymist-tmu2.o-cflags := $(X11_CFLAGS)
++milkymist-tmu2.o-libs := $(X11_LIBS)
+ 
+ obj-$(CONFIG_OMAP) += omap_dss.o
+ obj-$(CONFIG_OMAP) += omap_lcdc.o
+diff --git a/ui/Makefile.objs b/ui/Makefile.objs
+index cc784346cb..00f6976c30 100644
+--- a/ui/Makefile.objs
++++ b/ui/Makefile.objs
+@@ -15,10 +15,6 @@ common-obj-$(CONFIG_COCOA) += cocoa.o
+ common-obj-$(CONFIG_VNC) += $(vnc-obj-y)
+ common-obj-$(call lnot,$(CONFIG_VNC)) += vnc-stubs.o
+ 
+-common-obj-$(CONFIG_X11) += x_keymap.o
+-x_keymap.o-cflags := $(X11_CFLAGS)
+-x_keymap.o-libs := $(X11_LIBS)
+-
+ # ui-sdl module
+ common-obj-$(CONFIG_SDL) += sdl.mo
+ ifeq ($(CONFIG_SDLABI),1.2)
+@@ -46,6 +42,13 @@ gtk.mo-objs += gtk-gl-area.o
+ endif
+ endif
+ 
++ifeq ($(CONFIG_X11),y)
++sdl.mo-objs += x_keymap.o
++gtk.mo-objs += x_keymap.o
++x_keymap.o-cflags := $(X11_CFLAGS)
++x_keymap.o-libs := $(X11_LIBS)
++endif
++
+ common-obj-$(CONFIG_CURSES) += curses.mo
+ curses.mo-objs := curses.o
+ curses.mo-cflags := $(CURSES_CFLAGS)
+-- 
+2.17.0
+

--- a/aports/main/qemu/0006-linux-user-signal.c-define-__SIGRTMIN-MAX-for-non-GN.patch
+++ b/aports/main/qemu/0006-linux-user-signal.c-define-__SIGRTMIN-MAX-for-non-GN.patch
@@ -1,0 +1,37 @@
+From 3e231fa7a2dc66e2ef06ac44f4f719b08fc0c67e Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Tue, 29 Apr 2014 15:51:31 +0200
+Subject: [PATCH 6/6] linux-user/signal.c: define __SIGRTMIN/MAX for non-GNU
+ platforms
+
+The __SIGRTMIN and __SIGRTMAX are glibc internals and are not available
+on all platforms, so we define those if they are missing.
+
+This is needed for musl libc.
+
+Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>
+---
+ linux-user/signal.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/linux-user/signal.c b/linux-user/signal.c
+index 7d6246f..6019dbb 100644
+--- a/linux-user/signal.c
++++ b/linux-user/signal.c
+@@ -32,6 +32,13 @@
+ 
+ //#define DEBUG_SIGNAL
+ 
++#ifndef __SIGRTMIN
++#define __SIGRTMIN 32
++#endif
++#ifndef __SIGRTMAX
++#define __SIGRTMAX (NSIG-1)
++#endif
++
+ static struct target_sigaltstack target_sigaltstack_used = {
+     .ss_sp = 0,
+     .ss_size = 0,
+-- 
+1.9.2
+

--- a/aports/main/qemu/80-kvm.rules
+++ b/aports/main/qemu/80-kvm.rules
@@ -1,0 +1,1 @@
+KERNEL=="kvm", GROUP="kvm", MODE="0666"

--- a/aports/main/qemu/APKBUILD
+++ b/aports/main/qemu/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=qemu
 pkgver=2.12.0
-pkgrel=3
+pkgrel=4
 pkgdesc="QEMU is a generic machine emulator and virtualizer"
 url="http://qemu.org/"
 arch="all"
@@ -28,6 +28,7 @@ makedepends="
 	lzo-dev
 	ncurses-dev
 	paxmark
+	sdl-dev
 	sdl2-dev
 	snappy-dev
 	spice-dev
@@ -35,10 +36,12 @@ makedepends="
 	usbredir-dev
 	util-linux-dev
 	vde2-dev
+	virglrenderer-dev
 	vte3-dev
 	xfsprogs-dev
 	zlib-dev
 	"
+depends="virglrenderer mesa-dri-virtio mesa-dri-swrast"
 pkggroups="qemu"
 install="$pkgname.pre-install $pkgname.post-install"
 # suid needed for qemu-bridge-helper
@@ -255,6 +258,7 @@ build() {
 		--enable-linux-aio \
 		--enable-lzo \
 		--enable-modules \
+		--enable-opengl \
 		--enable-pie \
 		--enable-sdl \
 		--enable-snappy \
@@ -263,6 +267,7 @@ build() {
 		--enable-usb-redir \
 		--enable-vde \
 		--enable-vhost-net \
+		--enable-virglrenderer \
 		--enable-virtfs \
 		--enable-vnc \
 		--enable-vnc-jpeg \

--- a/aports/main/qemu/APKBUILD
+++ b/aports/main/qemu/APKBUILD
@@ -1,0 +1,397 @@
+pkgname=qemu
+pkgver=2.12.0
+pkgrel=3
+pkgdesc="QEMU is a generic machine emulator and virtualizer"
+url="http://qemu.org/"
+arch="all"
+license="GPL-2.0 LGPL-2"
+makedepends="
+	alsa-lib-dev
+	bison
+	curl-dev
+	flex
+	glib-dev
+	glib-static
+	gnutls-dev
+	gtk+3.0-dev
+	libaio-dev
+	libcap-dev
+	libcap-ng-dev
+	libjpeg-turbo-dev
+	libnfs-dev
+	libpng-dev
+	libseccomp-dev
+	libssh2-dev
+	libusb-dev
+	libxml2-dev
+	linux-headers
+	lzo-dev
+	ncurses-dev
+	paxmark
+	sdl2-dev
+	snappy-dev
+	spice-dev
+	texinfo
+	usbredir-dev
+	util-linux-dev
+	vde2-dev
+	vte3-dev
+	xfsprogs-dev
+	zlib-dev
+	"
+pkggroups="qemu"
+install="$pkgname.pre-install $pkgname.post-install"
+# suid needed for qemu-bridge-helper
+# strip fails on .img files
+# some tests does not run on our builders
+options="suid !strip !check"
+subpackages="$pkgname-doc $pkgname-lang $pkgname-guest-agent:guest
+	ivshmem-tools:_ivshmem"
+
+_subsystems="
+	aarch64
+	aarch64_be
+	alpha
+	arm
+	armeb
+	cris
+	hppa
+	i386
+	m68k
+	microblaze
+	microblazeel
+	mips
+	mips64
+	mips64el
+	mipsel
+	mipsn32
+	mipsn32el
+	nios2
+	or1k
+	ppc
+	ppc64
+	ppc64abi32
+	ppc64le
+	riscv32
+	riscv64
+	s390x
+	sh4
+	sh4eb
+	sparc
+	sparc32plus
+	sparc64
+	system-aarch64
+	system-alpha
+	system-arm
+	system-cris
+	system-hppa
+	system-i386
+	system-lm32
+	system-m68k
+	system-microblaze
+	system-microblazeel
+	system-mips
+	system-mips64
+	system-mips64el
+	system-mipsel
+	system-moxie
+	system-nios2
+	system-or1k
+	system-ppc
+	system-ppc64
+	system-ppcemb
+	system-riscv32
+	system-riscv64
+	system-s390x
+	system-sh4
+	system-sh4eb
+	system-sparc
+	system-sparc64
+	system-tricore
+	system-unicore32
+	system-x86_64
+	system-xtensa
+	system-xtensaeb
+	tilegx
+	x86_64
+	xtensa
+	xtensaeb
+	"
+for _sub in $_subsystems; do
+	subpackages="$subpackages $pkgname-$_sub:_subsys"
+done
+
+_modules="
+	audio-alsa
+	audio-oss
+	audio-sdl
+	block-curl
+	block-dmg-bz2
+	block-nfs
+	block-ssh
+	ui-curses
+	ui-gtk
+	ui-sdl
+	"
+for _mod in $_modules; do
+	subpackages="$subpackages $pkgname-$_mod:_module"
+done
+subpackages="$subpackages qemu-modules:_all_modules"
+
+subpackages="$subpackages $pkgname-img"  # -img must be declared the last
+
+source="http://wiki.qemu-project.org/download/$pkgname-$pkgver.tar.xz
+	0001-elfload-load-PIE-executables-to-right-address.patch
+	0006-linux-user-signal.c-define-__SIGRTMIN-MAX-for-non-GN.patch
+	0001-linux-user-fix-build-with-musl-on-aarch64.patch
+	musl-F_SHLCK-and-F_EXLCK.patch
+	fix-sigevent-and-sigval_t.patch
+	xattr_size_max.patch
+	ncurses.patch
+	ignore-signals-33-and-64-to-allow-golang-emulation.patch
+	0001-linux-user-fix-build-with-musl-on-ppc64le.patch
+	fix-sockios-header.patch
+	test-crypto-ivgen-skip-essiv.patch
+	0001-ui-add-x_keymap.o-to-modules.patch
+
+	$pkgname-guest-agent.confd
+	$pkgname-guest-agent.initd
+	80-kvm.rules
+	bridge.conf
+	"
+builddir="$srcdir/$pkgname-$pkgver"
+
+# secfixes:
+#   2.8.1-r1:
+#   - CVE-2016-7994
+#   - CVE-2016-7995
+#   - CVE-2016-8576
+#   - CVE-2016-8577
+#   - CVE-2016-8578
+#   - CVE-2016-8668
+#   - CVE-2016-8909
+#   - CVE-2016-8910
+#   - CVE-2016-9101
+#   - CVE-2016-9102
+#   - CVE-2016-9103
+#   - CVE-2016-9104
+#   - CVE-2016-9105
+#   - CVE-2016-9106
+#   - CVE-2017-2615
+#   - CVE-2017-2620
+#   - CVE-2017-5525
+#   - CVE-2017-5552
+#   - CVE-2017-5578
+#   - CVE-2017-5579
+#   - CVE-2017-5667
+#   - CVE-2017-5856
+#   - CVE-2017-5857
+#   - CVE-2017-5898
+#   - CVE-2017-5931
+
+prepare() {
+	default_prepare  # apply patches
+
+	sed -i 's/^VL_LDFLAGS=$/VL_LDFLAGS=-Wl,-z,execheap/' \
+		Makefile.target
+}
+
+_compile_common() {
+	CFLAGS="${CFLAGS/-Os/-O2}" "$builddir"/configure \
+		--prefix=/usr \
+		--localstatedir=/var \
+		--sysconfdir=/etc \
+		--libexecdir=/usr/lib/qemu \
+		--disable-glusterfs \
+		--disable-debug-info \
+		--disable-bsd-user \
+		--disable-werror \
+		--disable-xen \
+		--enable-kvm \
+		--enable-seccomp \
+		--cc="${CC:-gcc}" \
+		"$@"
+	make ARFLAGS="rc"
+}
+
+build() {
+	mkdir -p "$builddir"/build \
+		"$builddir"/build-static
+
+	cd "$builddir"/build-static
+	_compile_common \
+		--enable-linux-user \
+		--disable-system \
+		--static \
+		--disable-sdl \
+		--disable-gtk \
+		--disable-spice \
+		--disable-tools \
+		--disable-guest-agent \
+		--disable-guest-agent-msi \
+		--disable-curses \
+		--disable-curl \
+		--disable-gnutls \
+		--disable-gcrypt \
+		--disable-nettle \
+		--disable-cap-ng \
+		--disable-brlapi \
+		--disable-mpath \
+		--disable-libnfs \
+		--disable-capstone
+
+	cd "$builddir"/build
+	_compile_common \
+		--disable-linux-user \
+		--audio-drv-list=oss,alsa,sdl \
+		--enable-cap-ng \
+		--enable-curl \
+		--enable-curses \
+		--enable-docs \
+		--enable-gtk \
+		--enable-guest-agent \
+		--enable-libnfs \
+		--enable-libssh2 \
+		--enable-linux-aio \
+		--enable-lzo \
+		--enable-modules \
+		--enable-pie \
+		--enable-sdl \
+		--enable-snappy \
+		--enable-spice \
+		--enable-tpm \
+		--enable-usb-redir \
+		--enable-vde \
+		--enable-vhost-net \
+		--enable-virtfs \
+		--enable-vnc \
+		--enable-vnc-jpeg \
+		--enable-vnc-png \
+		--with-gtkabi=3.0 \
+		--with-sdlabi=2.0 \
+		--tls-priority=@QEMU,SYSTEM
+}
+
+check() {
+	cd "$builddir"/build
+
+	# XXX: ESSIV crypto tests are disabled, see test-crypto-ivgen-skip-essiv.patch.
+	make check V=1
+}
+
+package() {
+	cd "$builddir"/build-static
+	make DESTDIR="$pkgdir" install
+
+	cd "$builddir"/build
+	make DESTDIR="$pkgdir" install
+	paxmark -m "$pkgdir"/usr/bin/qemu-system-*
+
+	install -Dm640 -g qemu "$srcdir"/bridge.conf \
+		"$pkgdir"/etc/qemu/bridge.conf
+
+	install -Dm644 "$srcdir"/80-kvm.rules \
+		"$pkgdir"/lib/udev/rules.d/80-kvm.rules
+
+	# qemu-bridge-helper needs suid to create tunX devices;
+	# allow only users in the qemu group to run it.
+	chmod 04710 "$pkgdir"/usr/lib/qemu/qemu-bridge-helper
+	chgrp qemu "$pkgdir"/usr/lib/qemu/qemu-bridge-helper
+
+	# Do not install HTML docs.
+	rm "$pkgdir"/usr/share/doc/qemu/*.html
+}
+
+_subsys() {
+	local name=${1:-"${subpkgname#$pkgname-}"}
+	pkgdesc="Qemu ${name/-/ } emulator"
+	options=""
+	depends=""
+	case "$name" in
+		system*) depends="qemu";;
+	esac
+
+	mkdir -p "$subpkgdir"/usr/bin
+	mv "$pkgdir"/usr/bin/qemu-$name "$subpkgdir"/usr/bin/
+}
+
+_ivshmem() {
+	pkgdesc="Client and server for QEMU ivshmem device"
+	mkdir -p "$subpkgdir"/usr/bin
+	mv "$pkgdir"/usr/bin/ivshmem-* "$subpkgdir"/usr/bin/
+}
+
+img() {
+	pkgdesc="QEMU command line tool for manipulating disk images"
+	depends=""
+	options=""
+
+	mkdir -p "$subpkgdir"/usr/bin
+	mv "$pkgdir"/usr/bin/qemu-img \
+		"$pkgdir"/usr/bin/qemu-io \
+		"$pkgdir"/usr/bin/qemu-nbd \
+		"$subpkgdir"/usr/bin/
+
+	# We exploit the fact that -img subpackage are created last
+	# and check that we done have new systems that belongs in
+	# subpackage.
+	local path= retval=0
+	for path in "$pkgdir"/usr/bin/qemu-system-* "$pkgdir"/usr/lib/qemu/*.so; do
+		if [ -r "$path" ]; then
+			error "Please create a subpackage for ${path##*/}"
+			retval=1
+		fi
+	done
+	return $retval
+}
+
+guest() {
+	pkgdesc="QEMU guest agent"
+	depends=""
+	options=""
+
+	mkdir -p "$subpkgdir"/usr/bin
+	mv "$pkgdir"/usr/bin/qemu-ga "$subpkgdir"/usr/bin/
+
+	install -Dm755 "$srcdir"/$pkgname-guest-agent.initd \
+		"$subpkgdir"/etc/init.d/$pkgname-guest-agent
+	install -Dm644 "$srcdir"/$pkgname-guest-agent.confd \
+		"$subpkgdir"/etc/conf.d/$pkgname-guest-agent
+}
+
+_module() {
+	local _mod=${subpkgname#qemu-}
+	local _class=${_mod%%-*}
+	local _m=${_mod#*-}
+	pkgdesc="Qemu $_m $_class module"
+	mkdir -p "$subpkgdir"/usr/lib/qemu
+	mv "$pkgdir"/usr/lib/qemu/$_mod.so \
+		"$subpkgdir"/usr/lib/qemu/
+}
+
+_all_modules() {
+	pkgdesc="Meta package for all qemu modules"
+	local _i
+	for _i in $_modules; do
+		depends="$depends qemu-$_i"
+	done
+	mkdir -p "$subpkgdir"
+}
+
+sha512sums="dda057c52cf5fe460b029448049266ace061d21fb5f1cf71a6a37f67b3b7fc3350f6712bf22803fc38fa91f0bd438896ba01b5817b3b94ba9b6925aeaae053b7  qemu-2.12.0.tar.xz
+405008589cad1c8b609eca004d520bf944366e8525f85a19fc6e283c95b84b6c2429822ba064675823ab69f1406a57377266a65021623d1cd581e7db000134fd  0001-elfload-load-PIE-executables-to-right-address.patch
+ec84b27648c01c6e58781295dcd0c2ff8e5a635f9836ef50c1da5d0ed125db1afc4cb5b01cb97606d6dd8f417acba93e1560d9a32ca29161a4bb730b302440ea  0006-linux-user-signal.c-define-__SIGRTMIN-MAX-for-non-GN.patch
+1ac043312864309e19f839a699ab2485bca51bbf3d5fdb39f1a87b87e3cbdd8cbda1a56e6b5c9ffccd65a8ac2f600da9ceb8713f4dbba26f245bc52bcd8a1c56  0001-linux-user-fix-build-with-musl-on-aarch64.patch
+224f5b44da749921e8a821359478c5238d8b6e24a9c0b4c5738c34e82f3062ec4639d495b8b5883d304af4a0d567e38aa6623aac1aa3a7164a5757c036528ac0  musl-F_SHLCK-and-F_EXLCK.patch
+5da8114b9bd2e62f0f1f0f73f393fdbd738c5dea827ea60cedffd6f6edd0f5a97489c7148d37a8ec5a148d4e65d75cbefe9353714ee6b6f51a600200133fc914  fix-sigevent-and-sigval_t.patch
+4b1e26ba4d53f9f762cbd5cea8ef6f8062d827ae3ae07bc36c5b0c0be4e94fc1856ad2477e8e791b074b8a25d51ed6d0ddd75e605e54600e5dd0799143793ce4  xattr_size_max.patch
+b6ed02aaf95a9bb30a5f107d35371207967edca058f3ca11348b0b629ea7a9c4baa618db68a3df72199eea6d86d14ced74a5a229d17604cc3f0adedcfeae7a73  ncurses.patch
+fd178f2913639a0c33199b3880cb17536961f2b3ff171c12b27f4be6bca032d6b88fd16302d09c692bb34883346babef5c44407a6804b20a39a465bb2bc85136  ignore-signals-33-and-64-to-allow-golang-emulation.patch
+d8933df9484158c2b4888254e62117d78f8ed7c18527b249419f39c2b2ab1afa148010884b40661f8965f1ef3105580fceffdfddbb2c9221dc1c62066722ba65  0001-linux-user-fix-build-with-musl-on-ppc64le.patch
+39590476a4ebd7c1e79a4f0451b24c75b1817a2a83abaa1f71bb60b225d772152f0af8f3e51ff65645e378c536ffa6ff551dade52884d03a14b7c6a19c5c97d4  fix-sockios-header.patch
+8b8db136f78bd26b5da171effa9e11016ec2bc3e2fc8107228b5543b47aa370978ed883794aa4f917f334e284a5b49e82070e1da2d31d49301195b6713a48eff  test-crypto-ivgen-skip-essiv.patch
+e052ece28af1e7a81828322999b6f1ff5c030c717a897fe80ea04d5ba7f9d477786d91cfbf2eb3444c46b1bc8d3b72a771c26c819bc3ecfd216dd02b6567796e  0001-ui-add-x_keymap.o-to-modules.patch
+d90c034cae3f9097466854ed1a9f32ab4b02089fcdf7320e8f4da13b2b1ff65067233f48809911485e4431d7ec1a22448b934121bc9522a2dc489009e87e2b1f  qemu-guest-agent.confd
+1cd24c2444c5935a763c501af2b0da31635aad9cf62e55416d6477fcec153cddbe7de205d99616def11b085e0dd366ba22463d2270f831d884edbc307c7864a6  qemu-guest-agent.initd
+9b7a89b20fcf737832cb7b4d5dc7d8301dd88169cbe5339eda69fbb51c2e537d8cb9ec7cf37600899e734209e63410d50d0821bce97e401421db39c294d97be2  80-kvm.rules
+749efa2e764006555b4fd3a8e2f6d1118ad2ea4d45acf99104a41a93cfe66dc9685f72027c17d8211e5716246c2a52322c962cf4b73b27541b69393cd57f53bb  bridge.conf"

--- a/aports/main/qemu/APKBUILD
+++ b/aports/main/qemu/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=qemu
 pkgver=2.12.0
-pkgrel=4
+pkgrel=5
 pkgdesc="QEMU is a generic machine emulator and virtualizer"
 url="http://qemu.org/"
 arch="all"
@@ -156,6 +156,7 @@ source="http://wiki.qemu-project.org/download/$pkgname-$pkgver.tar.xz
 	fix-sockios-header.patch
 	test-crypto-ivgen-skip-essiv.patch
 	0001-ui-add-x_keymap.o-to-modules.patch
+	0001-module-Use-QEMU_MODULE_PATH-as-a-search-path.patch
 
 	$pkgname-guest-agent.confd
 	$pkgname-guest-agent.initd
@@ -396,6 +397,7 @@ d8933df9484158c2b4888254e62117d78f8ed7c18527b249419f39c2b2ab1afa148010884b40661f
 39590476a4ebd7c1e79a4f0451b24c75b1817a2a83abaa1f71bb60b225d772152f0af8f3e51ff65645e378c536ffa6ff551dade52884d03a14b7c6a19c5c97d4  fix-sockios-header.patch
 8b8db136f78bd26b5da171effa9e11016ec2bc3e2fc8107228b5543b47aa370978ed883794aa4f917f334e284a5b49e82070e1da2d31d49301195b6713a48eff  test-crypto-ivgen-skip-essiv.patch
 e052ece28af1e7a81828322999b6f1ff5c030c717a897fe80ea04d5ba7f9d477786d91cfbf2eb3444c46b1bc8d3b72a771c26c819bc3ecfd216dd02b6567796e  0001-ui-add-x_keymap.o-to-modules.patch
+320ecf95274ed42402fd0e6e1779906abea36891945888649ae4df80a7021cf4c7a6f96a3bb525103ecbf3193300a11484f523c2acb6ddbf2504374171853de2  0001-module-Use-QEMU_MODULE_PATH-as-a-search-path.patch
 d90c034cae3f9097466854ed1a9f32ab4b02089fcdf7320e8f4da13b2b1ff65067233f48809911485e4431d7ec1a22448b934121bc9522a2dc489009e87e2b1f  qemu-guest-agent.confd
 1cd24c2444c5935a763c501af2b0da31635aad9cf62e55416d6477fcec153cddbe7de205d99616def11b085e0dd366ba22463d2270f831d884edbc307c7864a6  qemu-guest-agent.initd
 9b7a89b20fcf737832cb7b4d5dc7d8301dd88169cbe5339eda69fbb51c2e537d8cb9ec7cf37600899e734209e63410d50d0821bce97e401421db39c294d97be2  80-kvm.rules

--- a/aports/main/qemu/bridge.conf
+++ b/aports/main/qemu/bridge.conf
@@ -1,0 +1,9 @@
+# This should have the following permissions: root:qemu 0640
+
+# Allow users in the "qemu" group to add devices to "br0".
+#allow br0
+
+# Uncomment the following line to allow users in the "bob"
+# group to have permissions defined in it, iff it has the
+# following permissions: root:bob 0640
+#include /etc/qemu/bob.conf

--- a/aports/main/qemu/fix-sigevent-and-sigval_t.patch
+++ b/aports/main/qemu/fix-sigevent-and-sigval_t.patch
@@ -1,0 +1,24 @@
+--- qemu-2.2.1/linux-user/syscall.c.orig	2015-04-10 07:10:06.305662505 +0000
++++ qemu-2.2.1/linux-user/syscall.c	2015-04-10 07:36:53.801871968 +0000
+@@ -5020,9 +5020,20 @@
+     return 0;
+ }
+ 
+-static inline abi_long target_to_host_sigevent(struct sigevent *host_sevp,
++struct host_sigevent {
++    union sigval sigev_value;
++    int sigev_signo;
++    int sigev_notify;
++    union {
++       int _pad[64-sizeof(int) * 2 + sizeof(union sigval)];
++       int _tid;
++    } _sigev_un;
++};
++
++static inline abi_long target_to_host_sigevent(struct sigevent *sevp,
+                                                abi_ulong target_addr)
+ {
++    struct host_sigevent *host_sevp = (struct host_sigevent *) sevp;
+     struct target_sigevent *target_sevp;
+ 
+     if (!lock_user_struct(VERIFY_READ, target_sevp, target_addr, 1)) {

--- a/aports/main/qemu/fix-sockios-header.patch
+++ b/aports/main/qemu/fix-sockios-header.patch
@@ -1,0 +1,13 @@
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 43d0562..afa0ac4 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -59,6 +59,7 @@ int __clone2(int (*fn)(void *), void *child_stack_base,
+ #include <linux/icmp.h>
+ #include <linux/icmpv6.h>
+ #include <linux/errqueue.h>
++#include <linux/sockios.h>
+ #include <linux/random.h>
+ #include "qemu-common.h"
+ #ifdef CONFIG_TIMERFD
+ #include <sys/timerfd.h>

--- a/aports/main/qemu/ignore-signals-33-and-64-to-allow-golang-emulation.patch
+++ b/aports/main/qemu/ignore-signals-33-and-64-to-allow-golang-emulation.patch
@@ -1,0 +1,56 @@
+From db186a3f83454268c43fc793a48bc28c41368a6c Mon Sep 17 00:00:00 2001
+From: Petros Angelatos <petrosagg@gmail.com>
+Date: Thu, 3 Mar 2016 23:58:53 -0800
+Subject: [PATCH] linux-user: ignore signals 33 and 64 to allow golang
+ emulation
+
+Signal 33 will always fail. This causes golang crash since
+https://github.com/golang/go/commit/675eb72c285cd0dd44a5f280bb3fa456ddf6de16
+
+As explained in that commit, these signals are very rarely used in a
+way that causes problems, so it's ok-ish to ignore one of them.
+
+Signal 64 will fail because QEMU uses SIGRTMAX for itself. This causes
+golang to crash for versions earlier than
+https://github.com/golang/go/commit/d10675089d74db0408f2432eae3bd89a8e1c2d6a
+
+Since after that commit golang ignores that signal, we also ignore it here to
+allow earlier versions to run as well.
+
+Signed-off-by: Petros Angelatos <petrosagg@gmail.com>
+---
+ linux-user/signal.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/linux-user/signal.c b/linux-user/signal.c
+index 9a4d894..90aca55 100644
+--- a/linux-user/signal.c
++++ b/linux-user/signal.c
+@@ -744,6 +744,27 @@ int do_sigaction(int sig, const struct target_sigaction *act,
+     }
+ 
+     k = &sigact_table[sig - 1];
++
++    /* This signal will always fail. This causes golang crash since
++     * https://github.com/golang/go/commit/675eb72c285cd0dd44a5f280bb3fa456ddf6de16
++     *
++     * As explained in that commit, these signals are very rarely used in a
++     * way that causes problems, so it's ok-ish to ignore one of them here.
++     */
++    if (sig == 33) {
++        return 0;
++    }
++    /* This signal will fail because QEMU uses SIGRTMAX for itself. This causes
++     * golang to crash for versions earlier than
++     * https://github.com/golang/go/commit/d10675089d74db0408f2432eae3bd89a8e1c2d6a
++     *
++     * Since after that commit golang ignores that signal, we also ignore it here to
++     * allow earlier versions to run as well.
++     */
++    if (sig == 64) {
++        return 0;
++    }
++
+     if (oact) {
+         __put_user(k->_sa_handler, &oact->_sa_handler);
+         __put_user(k->sa_flags, &oact->sa_flags);

--- a/aports/main/qemu/musl-F_SHLCK-and-F_EXLCK.patch
+++ b/aports/main/qemu/musl-F_SHLCK-and-F_EXLCK.patch
@@ -1,0 +1,19 @@
+This patch was not upstreamed to qemu as those should probably be
+defined in musl libc.
+
+--- ./linux-user/syscall.c.orig
++++ ./linux-user/syscall.c
+@@ -114,6 +114,13 @@
+ 
+ #include "qemu.h"
+ 
++#ifndef F_SHLCK
++#define F_SHLCK 8
++#endif
++#ifndef F_EXLCK
++#define F_EXLCK 4
++#endif
++
+ #ifndef CLONE_IO
+ #define CLONE_IO                0x80000000      /* Clone io context */
+ #endif

--- a/aports/main/qemu/ncurses.patch
+++ b/aports/main/qemu/ncurses.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 3770d7c..3fe8281 100755
+--- a/configure
++++ b/configure
+@@ -2928,7 +2928,7 @@ if test "$curses" != "no" ; then
+     curses_inc_list="$($pkg_config --cflags ncurses 2>/dev/null):"
+     curses_lib_list="$($pkg_config --libs ncurses 2>/dev/null):-lpdcurses"
+   else
+-    curses_inc_list="$($pkg_config --cflags ncursesw 2>/dev/null):-I/usr/include/ncursesw:"
++    curses_inc_list="-DNCURSES_WIDECHAR=1 $($pkg_config --cflags ncursesw 2>/dev/null):-I/usr/include/ncursesw:"
+     curses_lib_list="$($pkg_config --libs ncursesw 2>/dev/null):-lncursesw:-lcursesw"
+   fi
+   curses_found=no

--- a/aports/main/qemu/qemu-guest-agent.confd
+++ b/aports/main/qemu/qemu-guest-agent.confd
@@ -1,0 +1,7 @@
+# Specifies the transport method used to communicate to QEMU on the host side
+# Default: virtio-serial
+#GA_METHOD="virtio-serial"
+
+# Specifies the device path for the communications back to QEMU on the host
+# Default: /dev/virtio-ports/org.qemu.guest_agent.0
+#GA_PATH="/dev/virtio-ports/org.qemu.guest_agent.0"

--- a/aports/main/qemu/qemu-guest-agent.initd
+++ b/aports/main/qemu/qemu-guest-agent.initd
@@ -1,0 +1,6 @@
+#!/sbin/openrc-run
+
+name="QEMU Guest Agent"
+pidfile="/run/qemu-ga.pid"
+command="/usr/bin/qemu-ga"
+command_args="-m ${GA_METHOD:-virtio-serial} -p ${GA_PATH:-/dev/virtio-ports/org.qemu.guest_agent.0} -l /var/log/qemu-ga.log -d"

--- a/aports/main/qemu/qemu.post-install
+++ b/aports/main/qemu/qemu.post-install
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+cat 1>&2 <<EOF
+*
+* If you want to run VM as unprivileged user and let Qemu create tunX devices,
+* then you must add that user to the group "qemu".
+* If you use KVM for hardware-assisted virtualization, then you may also need
+* to add that user to the group "kvm".
+*
+EOF

--- a/aports/main/qemu/qemu.pre-install
+++ b/aports/main/qemu/qemu.pre-install
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+addgroup -S -g 34 kvm 2>/dev/null
+addgroup -S -g 36 qemu 2>/dev/null
+
+exit 0

--- a/aports/main/qemu/test-crypto-ivgen-skip-essiv.patch
+++ b/aports/main/qemu/test-crypto-ivgen-skip-essiv.patch
@@ -1,0 +1,54 @@
+These tests fail with Illegal instruction and I don't have a clue why,
+so skip them for now.
+
+--- a/tests/test-crypto-ivgen.c
++++ b/tests/test-crypto-ivgen.c
+@@ -88,48 +88,6 @@
+                                "\x00\x00\x00\x00\x00\x00\x00\x00",
+         .niv = 16,
+     },
+-    /* Small */
+-    {
+-        "/crypto/ivgen/essiv/1",
+-        .sector = 0x1,
+-        .ivalg = QCRYPTO_IVGEN_ALG_ESSIV,
+-        .cipheralg = QCRYPTO_CIPHER_ALG_AES_128,
+-        .hashalg = QCRYPTO_HASH_ALG_SHA256,
+-        .key = (const uint8_t *)"\x00\x01\x02\x03\x04\x05\x06\x07"
+-                                "\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f",
+-        .nkey = 16,
+-        .iv = (const uint8_t *)"\xd4\x83\x71\xb2\xa1\x94\x53\x88"
+-                               "\x1c\x7a\x2d\06\x2d\x0b\x65\x46",
+-        .niv = 16,
+-    },
+-    /* Big ! */
+-    {
+-        "/crypto/ivgen/essiv/1f2e3d4c",
+-        .sector = 0x1f2e3d4cULL,
+-        .ivalg = QCRYPTO_IVGEN_ALG_ESSIV,
+-        .cipheralg = QCRYPTO_CIPHER_ALG_AES_128,
+-        .hashalg = QCRYPTO_HASH_ALG_SHA256,
+-        .key = (const uint8_t *)"\x00\x01\x02\x03\x04\x05\x06\x07"
+-                                "\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f",
+-        .nkey = 16,
+-        .iv = (const uint8_t *)"\x5d\x36\x09\x5d\xc6\x9e\x5e\xe9"
+-                               "\xe3\x02\x8d\xd8\x7a\x3d\xe7\x8f",
+-        .niv = 16,
+-    },
+-    /* No Truncation */
+-    {
+-        "/crypto/ivgen/essiv/1f2e3d4c5b6a7988",
+-        .sector = 0x1f2e3d4c5b6a7988ULL,
+-        .ivalg = QCRYPTO_IVGEN_ALG_ESSIV,
+-        .cipheralg = QCRYPTO_CIPHER_ALG_AES_128,
+-        .hashalg = QCRYPTO_HASH_ALG_SHA256,
+-        .key = (const uint8_t *)"\x00\x01\x02\x03\x04\x05\x06\x07"
+-                                "\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f",
+-        .nkey = 16,
+-        .iv = (const uint8_t *)"\x58\xbb\x81\x94\x51\x83\x23\x23"
+-                               "\x7a\x08\x93\xa9\xdc\xd2\xd9\xab",
+-        .niv = 16,
+-    },
+ };
+ 
+ 

--- a/aports/main/qemu/xattr_size_max.patch
+++ b/aports/main/qemu/xattr_size_max.patch
@@ -1,0 +1,15 @@
+diff --git a/hw/9pfs/9p.c b/hw/9pfs/9p.c
+index faebd91..a0f15b6 100644
+--- a/hw/9pfs/9p.c
++++ b/hw/9pfs/9p.c
+@@ -25,6 +25,10 @@
+ #include "trace.h"
+ #include "migration/migration.h"
+ 
++#ifdef __linux__
++#include <linux/limits.h> /* for XATTR_SIZE_MAX */
++#endif
++
+ int open_fd_hw;
+ int total_open_fd;
+ static int open_fd_rc;

--- a/pmb/parse/arguments.py
+++ b/pmb/parse/arguments.py
@@ -124,6 +124,10 @@ def arguments_qemu(subparser):
     display.add_argument("--display", dest="qemu_display", const="sdl,gl=on",
                          help="Qemu's display parameter (default: sdl,gl=on)",
                          default="sdl,gl=on", nargs="?")
+
+    ret.add_argument("--host-qemu", dest="host_qemu", action='store_true',
+                     help="Use the host system's qemu even if guest arch == host arch")
+
     return ret
 
 

--- a/pmb/qemu/run.py
+++ b/pmb/qemu/run.py
@@ -98,6 +98,19 @@ def command_spice(args):
     return ["remote-viewer", "spice://127.0.0.1?port=" + args.spice_port]
 
 
+def is_native(args):
+    """
+    Check if guest system arch is native
+    :returns: True if guest system arch is the same as the host system arch
+    """
+    native = True
+    if args.arch:
+        arch1 = pmb.parse.arch.uname_to_qemu(args.arch_native)
+        arch2 = pmb.parse.arch.uname_to_qemu(args.arch)
+        native = (arch1 == arch2)
+    return native
+
+
 def command_qemu(args, arch, device, img_path, spice_enabled):
     """
     Generate the full qemu command with arguments to run postmarketOS
@@ -161,11 +174,7 @@ def command_qemu(args, arch, device, img_path, spice_enabled):
         raise RuntimeError("Architecture {} not supported by this command yet.".format(arch))
 
     # Kernel Virtual Machine (KVM) support
-    native = True
-    if args.arch:
-        arch1 = pmb.parse.arch.uname_to_qemu(args.arch_native)
-        arch2 = pmb.parse.arch.uname_to_qemu(args.arch)
-        native = (arch1 == arch2)
+    native = is_native(args)
     if native and os.path.exists("/dev/kvm"):
         command += ["-enable-kvm"]
     else:

--- a/pmb/qemu/run.py
+++ b/pmb/qemu/run.py
@@ -236,6 +236,18 @@ def sigterm_handler(number, frame):
                        " and killed the Qemu VM it was running.")
 
 
+def install_depends(args, arch):
+    """
+    Install any necessary qemu dependencies in native chroot
+    """
+    if is_native(args) and not args.host_qemu:
+        depends = ["qemu", "qemu-system-" + arch, "qemu-ui-sdl", "qemu-ui-gtk",
+                   "mesa-gl", "mesa-egl", "mesa-dri-ati", "mesa-dri-freedreno",
+                   "mesa-dri-intel", "mesa-dri-nouveau", "mesa-dri-swrast",
+                   "mesa-dri-virtio", "mesa-dri-vmwgfx"]
+        pmb.chroot.apk.install(args, depends)
+
+
 def run(args):
     """
     Run a postmarketOS image in qemu
@@ -244,6 +256,7 @@ def run(args):
     arch = pmb.parse.arch.uname_to_qemu(args.arch_native)
     if args.arch:
         arch = pmb.parse.arch.uname_to_qemu(args.arch)
+    install_depends(args, arch)
     device = pmb.parse.arch.qemu_to_pmos_device(arch)
     img_path = system_image(args, device)
     logging.info("Running postmarketOS in QEMU VM (" + arch + ")")


### PR DESCRIPTION
Use Alpine's QEMU rather than the host system QEMU (as described in issue #1158). The QEMU GTK/SDL version and Spice version are working as previously.

This also partially addresses #534. It forks Alpine's QEMU with two changes:
 - Compile with `virglrenderer`
 - Add patch to use `QEMU_MODDIR` env variable as a search path for QEMU modules which is required for GTK and SDL display.

There are two new `pmbootstrap` `--device` and `--vga` arguments which are passed to qemu's equivalent args. The virgl renderer is a buggy from my testing. These two parameters are the relevant ones used for testing virgl. Run it with:

```shell
pmbootstrap qemu --display sdl,gl=on --device (virtio-vga|virtio-gpu-pci),virgl=on --vga virtio
```
Sometimes it's useful to omit one or the other argument depending on the graphical environment I've had different results depending on which.

---
[x] Merge on GitHub (see <https://postmarketos.org/merge>)
