### PR TITLE
Add kdeconnect aport

### DIFF
--- a/aports/kde/kdeconnect/APKBUILD
+++ b/aports/kde/kdeconnect/APKBUILD
@@ -1,0 +1,57 @@
+# Contributor:
+# Maintainer:
+pkgname=kdeconnect
+pkgver=1.3.1_git20180621
+pkgrel=0
+_commit="0057c44a30cc5205b23db8bb48ac86a5a9a368e3"
+pkgdesc="Adds communication between KDE and your smartphone"
+url="https://community.kde.org/KDEConnect"
+arch="all"
+license="GPL-2.0"
+depends=""
+makedepends="extra-cmake-modules kdoctools-dev kconfigwidgets-dev kdbusaddons-dev kiconthemes-dev
+		knotifications-dev kio-dev kcmutils-dev qca-qt5-dev plasma-framework-dev libexecinfo-dev
+		qt5-qtdeclarative-dev"
+subpackages="$pkgname-doc $pkgname-mobile" #$pkgname-lang is only available in the release package
+#source="https://download.kde.org/stable/$pkgname/$pkgver/src/$pkgname-kde-$pkgver.tar.xz
+source="$pkgname-$_commit.tar.gz::https://github.com/KDE/$pkgname-kde/archive/$_commit.tar.gz"
+options="!check" # Requires running X11 server
+builddir="$srcdir/$pkgname-kde-$_commit"
+
+build() {
+	cd "$builddir"
+	cmake \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DBUILD_TESTING=ON \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DCMAKE_INSTALL_LIBEXECDIR=lib \
+		-DEXPERIMENTALAPP_ENABLED=true \
+		-DBUILD_TYPE=Release
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+mobile() {
+	depends="kirigami2"
+	install -d "$subpkgdir"/usr/share/applications
+	install -d "$subpkgdir"/usr/bin
+	install -d "$subpkgdir"/usr/lib/qt5/plugins/kdeconnect
+
+	mv "$pkgdir"/usr/bin/kcapp "$subpkgdir"/usr/bin/
+	mv "$pkgdir"/usr/share/applications/org.kde.kdeconnect.app.desktop "$subpkgdir"/usr/share/applications/	
+	mv "$pkgdir"/usr/lib/qt5/plugins/kdeconnect/kdeconnect_remotecommands.so "$subpkgdir"/usr/lib/qt5/plugins/kdeconnect/
+	mv "$pkgdir"/usr/lib/qt5/plugins/kdeconnect/kdeconnect_remotecontrol.so "$subpkgdir"/usr/lib/qt5/plugins/kdeconnect/
+	mv "$pkgdir"/usr/lib/qt5/plugins/kdeconnect/kdeconnect_lockdevice.so "$subpkgdir"/usr/lib/qt5/plugins/kdeconnect/
+	mv "$pkgdir"/usr/lib/qt5/plugins/kdeconnect/kdeconnect_mprisremote.so "$subpkgdir"/usr/lib/qt5/plugins/kdeconnect/
+}
+
+sha512sums="090914502aecb059a4ea2efe55d41c623d440698812fa62f848880677b8b931288b657fe317d556074f596f895806a299647004ab7e48935a74097065c2ed789  kdeconnect-0057c44a30cc5205b23db8bb48ac86a5a9a368e3.tar.gz"


### PR DESCRIPTION
So I don't have a device to test it on, but it runs in Qemu.

KDE Connect, mainly famous for it's Android app, has been working on making a mobile app for Plasma Mobile. Of course we want that too! The CMake line `-DEXPERIMENTALAPP_ENABLED=true` enables this app, and as the line itself says, it's still experimental. Things will be broken and we'll have to continuously update it, but that's part of the fun isn't it? Found bugs can be reported on (preferably) bugs.kde.org or on [Telegram](https://t.me/joinchat/AOS6gA37orb2dZCLhqbZjg).

It didn't compile at first due to a musl issue, but I [committed a fix](https://github.com/KDE/kdeconnect-kde/commit/0e90fe0bd06e687b2028d269db560a2bde7e79c8) for that.