### PR TITLE
device/device-raspberry-pi3: new aports

### DIFF
--- a/aports/device/device-raspberry-pi3/95-vchiq-permissions.rules
+++ b/aports/device/device-raspberry-pi3/95-vchiq-permissions.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="vchiq", GROUP="video", MODE="0660"

--- a/aports/device/device-raspberry-pi3/APKBUILD
+++ b/aports/device/device-raspberry-pi3/APKBUILD
@@ -7,7 +7,7 @@ url="https://postmarketos.org"
 license="MIT"
 arch="noarch"
 options="!check"
-depends="postmarketos-base raspberrypi-bootloader mesa-dri-vc4"
+depends="postmarketos-base raspberrypi-bootloader mesa-dri-vc4 bluetooth-raspberry-pi"
 makedepends="devicepkg-dev"
 subpackages="
 	$pkgname-kernel-rpi:kernel_rpi

--- a/aports/device/device-raspberry-pi3/APKBUILD
+++ b/aports/device/device-raspberry-pi3/APKBUILD
@@ -29,7 +29,7 @@ package() {
 }
 
 kernel_rpi() {
-	pkgdesc="Kernel for the Raspberry Pi 3B/3B+"
+	pkgdesc="Kernel for the Raspberry Pi 3B/3B+ (from Alpine, depends on non free firmware!)"
 	depends="$pkgname linux-rpi"
 	install="$subpkgname.post-install"
 	mkdir "$subpkgdir"

--- a/aports/device/device-raspberry-pi3/APKBUILD
+++ b/aports/device/device-raspberry-pi3/APKBUILD
@@ -1,0 +1,50 @@
+# Reference: <https://postmarketos.org/devicepkg>
+pkgname="device-raspberry-pi3"
+pkgdesc="Raspberry Pi 3B/3B+"
+pkgver=0.1
+pkgrel=1
+url="https://postmarketos.org"
+license="MIT"
+arch="noarch"
+options="!check"
+depends="postmarketos-base raspberrypi-bootloader mesa-dri-vc4"
+makedepends="devicepkg-dev"
+subpackages="
+	$pkgname-kernel-rpi:kernel_rpi
+	$pkgname-weston
+"
+source="deviceinfo config.txt usercfg.txt cmdline.txt 95-vchiq-permissions.rules weston.ini"
+
+build() {
+	devicepkg_build $startdir $pkgname
+}
+
+package() {
+	devicepkg_package $startdir $pkgname
+	install -Dm644 "$srcdir"/config.txt "$pkgdir"/boot/config.txt
+	install -Dm644 "$srcdir"/usercfg.txt "$pkgdir"/boot/usercfg.txt
+	install -Dm644 "$srcdir"/cmdline.txt "$pkgdir"/boot/cmdline.txt
+	install -Dm644 "$srcdir"/95-vchiq-permissions.rules \
+		"$pkgdir"/etc/udev/rules.d/95-vchiq-permissions.rules
+}
+
+kernel_rpi() {
+	pkgdesc="Kernel for the Raspberry Pi 3B/3B+"
+	depends="$pkgname linux-rpi"
+	install="$subpkgname.post-install"
+	mkdir "$subpkgdir"
+}
+
+weston() {
+	install_if="$pkgname weston"
+	install -Dm644 "$srcdir"/weston.ini \
+		"$subpkgdir"/etc/xdg/weston/weston.ini
+}
+
+
+sha512sums="cef722b6f87734b24a72f08e854c2ddc43afb4bc3edd8b5c1c6ca7049152493c423a7bbdeae20346906d69c64f61988a61aa640d9e0028c3f0806897861499ea  deviceinfo
+b95a66c8fa165aca2170ebb3f8688e78e1dd78d3ddb4d26c289ea77e406eec3bbfecb5a32997df86a692b674128d5b4f673c47f8e12013f33b765a69fec1cb51  config.txt
+a8e57535523d0f78e9d2ac1ac31b097a1a25468e3c910290647a60c862e631a4b4de94a5f6e4de999e1b9f70e67653a886967200856287dbc819b9f3ac16c548  usercfg.txt
+ae3de0b8fec07d3a283dc3c06bf8678eec1e65c9faf0b7f4fdc9fb92751e324d1f8e2fb224dbbf561b7e5a6fb34769bfa1657858375f74b101a130d78e0737e2  cmdline.txt
+7e5505cb07d5b4a81bd28443d508336b5c547356538f1c06f91ed93ad0d7d456d4f74f1d24df5a2e08c17e74f0a66607352ac4874e967e9a91dfec9522d2d58d  95-vchiq-permissions.rules
+320a466009c5abb416f70a60b45b3403ef1d1b4ac68a762c8028cd4615d537c48d906afe101e7335907a0274cc25b0b9b547e02ee69950e6792a7b54759c7cd9  weston.ini"

--- a/aports/device/device-raspberry-pi3/cmdline.txt
+++ b/aports/device/device-raspberry-pi3/cmdline.txt
@@ -1,0 +1,1 @@
+modules=loop,squashfs,sd-mod,usb-storage quiet dwc_otg.lpm_enable=0 console=ttyAMA0,115200 console=tty1

--- a/aports/device/device-raspberry-pi3/config.txt
+++ b/aports/device/device-raspberry-pi3/config.txt
@@ -1,0 +1,8 @@
+boot_delay=0
+
+arm_control=0x200
+
+kernel=vmlinuz-rpi
+initramfs initramfs-rpi
+
+include usercfg.txt

--- a/aports/device/device-raspberry-pi3/device-raspberry-pi3-kernel-rpi.post-install
+++ b/aports/device/device-raspberry-pi3/device-raspberry-pi3-kernel-rpi.post-install
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+kernver=$(cat /usr/share/kernel/rpi/kernel.release)
+cd /usr/lib/linux-${kernver}/
+find . -type f -regex ".*\.dtbo\?$" -exec install -Dm644 {} /boot/{} \;
+

--- a/aports/device/device-raspberry-pi3/deviceinfo
+++ b/aports/device/device-raspberry-pi3/deviceinfo
@@ -1,0 +1,24 @@
+# Reference: <https://postmarketos.org/deviceinfo>
+# Please use double quotes only. You can source this file in shell scripts.
+
+deviceinfo_format_version="0"
+deviceinfo_name="Raspberry Pi 3"
+deviceinfo_manufacturer="Raspberry Pi Foundation"
+deviceinfo_date=""
+deviceinfo_dtb=""
+deviceinfo_modules_initfs="vc4"
+deviceinfo_arch="aarch64"
+deviceinfo_disable_dhcpd="true"
+
+# Device related
+deviceinfo_keyboard="true"
+deviceinfo_external_storage="true"
+deviceinfo_screen_width="1920"
+deviceinfo_screen_height="1080"
+deviceinfo_dev_touchscreen=""
+deviceinfo_dev_touchscreen_calibration=""
+deviceinfo_dev_keyboard=""
+
+# Bootloader related
+deviceinfo_flash_method="none"
+deviceinfo_boot_filesystem="fat16"

--- a/aports/device/device-raspberry-pi3/usercfg.txt
+++ b/aports/device/device-raspberry-pi3/usercfg.txt
@@ -1,0 +1,21 @@
+gpu_mem=256
+gpu_mem_256=64
+
+# uncomment line to enable serial on ttyS0 on rpi3
+# NOTE: This fixes the core_freq to 250Mh
+#enable_uart=1
+
+# to take advantage of your high speed sd card
+dtparam=sd_overclock=100
+
+# use drm backend ( for weston and wayland )
+dtoverlay=vc4-fkms-v3d
+
+# have a properly sized image
+disable_overscan=1
+
+# for sound over HDMI
+hdmi_drive=2
+
+# Enable audio (loads snd_bcm2835)
+dtparam=audio=on

--- a/aports/device/device-raspberry-pi3/weston.ini
+++ b/aports/device/device-raspberry-pi3/weston.ini
@@ -1,0 +1,6 @@
+[core]
+xwayland=true
+backend=drm-backend.so
+
+[shell]
+background-image=/usr/share/wallpapers/postmarketos.jpg


### PR DESCRIPTION
add Raspberry Pi 3B/3B+(aarch64) support

5G wifi should work with `crda` installed and set wifi country code

notes: the support from raspberry pi upstream for arm64 is limited ([details](https://forums.gentoo.org/viewtopic-p-8106974.html#8106974)), no MMAL and no OpenMAX IL, also omxplayer is not available  

the previous PR: https://github.com/postmarketOS/pmbootstrap/pull/1568

due to I messed up that commit so it was closed, and recreate it now

the issues report in that PR: eth0 issues and pmos splash screen issues with vc4 should fixed now  

---
[x] Merge on GitHub (see <https://postmarketos.org/merge>)
